### PR TITLE
test on numpy release

### DIFF
--- a/scripts/f2py-f90wrap
+++ b/scripts/f2py-f90wrap
@@ -40,8 +40,8 @@ is generated. We make several changes to f2py:
 __all__ = []
 
 import numpy
-if not tuple([int(x) for x in numpy.__version__.split('.')[0:3]]) >= (1,2,1):
-   raise ImportError('f2py-f90wrap tested with numpy version 1.2.1 or later, found version %s' % numpy.__version__)
+if not tuple([int(x) for x in numpy.__version__.split('.')[0:2]]) >= (1,3):
+   raise ImportError('f2py-f90wrap tested with numpy version 1.3 or later, found version %s' % numpy.__version__)
 
 
 import numpy.f2py.auxfuncs

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ if (major, minor) < (2, 4):
 
 try:
     import numpy
-    if not tuple([int(x) for x in numpy.__version__.split('.')[0:3]]) >= (1, 2, 1):
+    if not tuple([int(x) for x in numpy.__version__.split('.')[0:2]]) >= (1, 3):
         raise ImportError
 except ImportError:
-    sys.stderr.write('Numpy 1.2.1 (http://www.numpy.org) or later needed to use this package\n')
+    sys.stderr.write('Numpy 1.3 (http://www.numpy.org) or later needed to use this package\n')
     sys.exit(1)
 
 from numpy.distutils.core import setup, Extension


### PR DESCRIPTION
Hello,

On some distributions, the installed numpy release is in the form of '1.7.1rc1', which breaks a test on the triplet of numeric values after splitting and converting the numpy.__version__
I suggest to limit the test on major and minor only, and to start at 1.3 as it is the first documented release of numpy and is already 6 years old anyway.

Cheers