### PR TITLE
added an extended derived type example, including allocatable arrays

### DIFF
--- a/examples/example-arrays/library.f90
+++ b/examples/example-arrays/library.f90
@@ -3,7 +3,7 @@ module library
     use parameters, only: idp, isp
     implicit none
     private
-    public :: do_array_stuff, only_manipulate
+    public :: do_array_stuff, only_manipulate, return_array
 
 contains
 
@@ -34,6 +34,17 @@ contains
             ENDDO
         ENDDO
     end subroutine only_manipulate
+
+    subroutine return_array(m, n, output)
+        INTEGER, INTENT(in) :: m, n
+        INTEGER, INTENT(out) :: output(m,n)
+        INTEGER :: i,j
+        DO i=1,m
+            DO j=1,n
+                output(i,j) = i*j + j
+            ENDDO
+        ENDDO
+    end subroutine return_array
 
 end module library
 

--- a/examples/example-arrays/tests.py
+++ b/examples/example-arrays/tests.py
@@ -49,6 +49,15 @@ class TestExample(unittest.TestCase):
         for k in range(4):
             np.testing.assert_allclose((x*y + x)**2, co[k,:])
 
+    def test_return_array(self):
+        m, n = 10, 4
+        arr = np.ndarray((m,n), order='F', dtype=np.int32)
+        lib.library.return_array(m, n, arr)
+        ii, jj = np.mgrid[0:m,0:n]
+        ii += 1
+        jj += 1
+        np.testing.assert_equal(ii*jj + jj, arr)
+
 
 if __name__ == '__main__':
 

--- a/examples/example-derivedtypes/Makefile
+++ b/examples/example-derivedtypes/Makefile
@@ -1,0 +1,140 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python2
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS = 
+endif
+
+CFLAGS = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = ExampleDerivedTypes
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=  
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = parameters datatypes library
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = datatypes library
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
+
+
+clean:
+	-rm ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}.so \
+	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
+
+
+test:
+	${PYTHON} tests.py
+

--- a/examples/example-derivedtypes/README.md
+++ b/examples/example-derivedtypes/README.md
@@ -1,0 +1,37 @@
+example-derived-types
+=====================
+
+Example with a set of subroutines, functions, arrays and derived types.
+This extends the ```example-array``` example.
+It is shown how to access and interact in Python with the Fortran based
+derived types and arrays. The example has been tested with both ```ifort```
+and ```gfortran```. The compiler can be set in the ```Makefile```.
+
+To build and wrap with f90wrap, use the included ```Makefile```:
+
+```
+make
+```
+
+and before rebuilding, clean-up with:
+
+```
+make clean
+```
+
+Simple unittest test cases are included in ```tests.py```.
+
+A sample memory profiling script is included in ```memory_profile.py```.
+To profile, run (you will need to have the Python module ```memory_profiler```
+installed):
+
+```
+python2 -m memory_profiler memory_profile.py
+```
+
+
+Author
+------
+
+David Verelst: <david.Verelst@gmail.com>
+

--- a/examples/example-derivedtypes/datatypes.f90
+++ b/examples/example-derivedtypes/datatypes.f90
@@ -1,0 +1,109 @@
+! ==============================================================================
+module datatypes_allocatable
+
+use parameters, only: idp, isp
+
+implicit none
+
+! Why do the alloc_arrays work here and not in the datatypes module??
+type alloc_arrays
+    REAL(idp), DIMENSION(:,:), ALLOCATABLE :: chi
+    REAL(idp), DIMENSION(:,:), ALLOCATABLE :: psi
+    INTEGER(4) chi_shape(2)
+    INTEGER(4) psi_shape(2)
+end type alloc_arrays
+
+contains
+
+subroutine init_alloc_arrays(dertype, m, n)
+    type(alloc_arrays), INTENT(inout) :: dertype
+    INTEGER(4), INTENT(in) :: m, n
+    allocate(dertype%chi(m,n))
+    allocate(dertype%psi(m,n))
+end subroutine init_alloc_arrays
+
+subroutine destroy_alloc_arrays(dertype)
+    type(alloc_arrays), INTENT(inout) :: dertype
+    if (allocated(dertype%chi)) deallocate(dertype%chi)
+    if (allocated(dertype%psi)) deallocate(dertype%psi)
+end subroutine destroy_alloc_arrays
+
+end module datatypes_allocatable
+! ==============================================================================
+
+! ==============================================================================
+module datatypes
+
+use parameters, only: idp, isp
+use datatypes_allocatable, only: alloc_arrays
+
+implicit none
+!private
+!public :: t_mass_data, t_element_data
+
+! NB: target attribute needed to allow derived type access from Python.
+! for gfortran, the mockdtderivetype use the following pre-processor flag:
+! #define type(x) TYPE(x), target
+! however, for my Linux-64bit installation, both gfortran (v5.2.0) and 
+! ifort (v15.0.3 20150407) did work fine withouth using the TARGET attribute
+
+type different_types
+    LOGICAL alpha
+    INTEGER(4) beta
+    REAL(idp) delta
+end type different_types
+
+! derived type with multiple arrays of vayring types, but fixed shape
+type fixed_shape_arrays
+    INTEGER(4) eta(10,4)
+    REAL(isp) theta(10,4)
+    REAL(idp) iota(10,4)
+end type fixed_shape_arrays
+
+type nested
+    type(different_types) mu
+    type(fixed_shape_arrays) nu
+end type nested
+
+! pointer arrays in a derived type are not accessible from Python
+type pointer_arrays
+    REAL(idp), DIMENSION(:,:), POINTER :: chi
+    REAL(idp), DIMENSION(:,:), POINTER :: psi
+    INTEGER(4) chi_shape(2)
+    INTEGER(4) psi_shape(2)
+end type pointer_arrays
+
+! why is this not working here??
+!type alloc_arrays
+!    REAL(idp), DIMENSION(:,:), ALLOCATABLE :: chi
+!    REAL(idp), DIMENSION(:,:), ALLOCATABLE :: psi
+!    INTEGER(4) chi_shape(2)
+!    INTEGER(4) psi_shape(2)
+!end type alloc_arrays
+
+type array_nested
+    type(different_types), DIMENSION(:), ALLOCATABLE :: xi
+    type(fixed_shape_arrays), DIMENSION(:), ALLOCATABLE :: omicron
+    type(alloc_arrays), DIMENSION(:), ALLOCATABLE :: pi
+end type array_nested
+
+contains
+
+subroutine init_array_nested(dertype, size)
+    type(array_nested), INTENT(inout) :: dertype
+    INTEGER(4), INTENT(in) :: size
+    allocate(dertype%xi(size))
+    allocate(dertype%omicron(size))
+    allocate(dertype%pi(size))
+end subroutine init_array_nested
+
+subroutine destroy_array_nested(dertype)
+    type(array_nested), INTENT(inout) :: dertype
+    if (allocated(dertype%xi)) deallocate(dertype%xi)
+    if (allocated(dertype%omicron)) deallocate(dertype%omicron)
+    if (allocated(dertype%pi)) deallocate(dertype%pi)
+end subroutine destroy_array_nested
+
+end module datatypes
+! ==============================================================================
+

--- a/examples/example-derivedtypes/kind_map
+++ b/examples/example-derivedtypes/kind_map
@@ -1,0 +1,17 @@
+{
+ 'real':     {   '' : 'float',
+                '4' : 'float',
+              'isp' : 'float',
+                '8' : 'double',
+               'dp' : 'double',
+              'idp' : 'double'},
+ 'complex' : {   '' : 'complex_float',
+ 	            '8' : 'complex_double',
+ 	           '16' : 'complex_long_double',
+ 	           'dp' : 'complex_double'},
+ 'integer' : {  '4' : 'int',
+	            '8' : 'long_long',
+	           'dp' : 'long_long' },
+ 'character' : {''  : 'char',
+                '1' : 'char' }
+}

--- a/examples/example-derivedtypes/library.f90
+++ b/examples/example-derivedtypes/library.f90
@@ -1,0 +1,186 @@
+module library
+
+    use parameters, only: idp, isp
+    implicit none
+
+contains
+
+    function return_value_func(val_in) result(val_out)
+        INTEGER(4) val_in, val_out
+        val_out = val_in + 10
+    end function return_value_func
+
+    subroutine return_value_sub(val_in, val_out)
+        INTEGER(4), INTENT(in) :: val_in
+        INTEGER(4), INTENT(out) :: val_out
+        val_out = val_in + 10
+    end subroutine return_value_sub
+
+    function return_a_dt_func() result(dt)
+        use datatypes, only: different_types
+        type(different_types) :: dt
+        dt%alpha = .true.
+        dt%beta = 666
+        dt%delta = 666.666_idp
+    end function return_a_dt_func
+
+    ! note that all memory allocation can now happen in Python
+    subroutine do_array_stuff(n,x,y,br,co)
+        INTEGER, INTENT(in) :: n
+        REAL(kind=idp), INTENT(in) :: x(n)
+        REAL(kind=idp), INTENT(in) :: y(n)
+        REAL(kind=idp), INTENT(out) :: br(n)
+        REAL(kind=idp), INTENT(out) :: co(4,n)
+        INTEGER :: i,j
+        
+        DO j=1,n
+            br(j) =  x(j) / ( y(j) + 1.0_idp )
+            DO i=1,4
+                co(i,j) = x(j)*y(j) + x(j)
+            ENDDO
+        ENDDO
+    end subroutine do_array_stuff
+
+    subroutine only_manipulate(n,array)
+        INTEGER, INTENT(in) :: n
+        REAL(kind=idp), INTENT(inout) :: array(4,n)
+        INTEGER :: i,j
+
+        DO j=1,n
+            DO i=1,4
+                array(i,j) = array(i,j)*array(i,j)
+            ENDDO
+        ENDDO
+    end subroutine only_manipulate
+
+    subroutine set_derived_type(dt, dt_beta, dt_delta)
+        use datatypes, only: different_types
+        INTEGER(4), INTENT(in) :: dt_beta
+        REAL(kind=idp), INTENT(in) :: dt_delta
+        TYPE(different_types), INTENT(out) :: dt
+
+        dt%beta = dt_beta
+        dt%delta = dt_delta
+    end subroutine set_derived_type
+
+    subroutine modify_derived_types(dt1, dt2, dt3)
+        use datatypes, only: different_types
+        TYPE(different_types), INTENT(inout) :: dt1, dt2, dt3
+        
+        dt1%beta = dt1%beta + 10
+        dt1%delta = dt1%delta + 10.0_idp
+
+        dt2%beta = dt2%beta + 20
+        dt2%delta = dt2%delta + 20.0_idp
+
+        dt3%beta = dt3%beta + 30
+        dt3%delta = dt3%delta + 30.0_idp
+    end subroutine modify_derived_types
+
+    subroutine modify_dertype_fixed_shape_arrays(dertype)
+        use datatypes, only: fixed_shape_arrays
+        TYPE(fixed_shape_arrays), INTENT(out) :: dertype
+        INTEGER :: i,j
+        dertype%eta(:,:) = 10
+        dertype%theta(:,:) = 2.0_isp
+        dertype%iota(:,:) = 100.0_idp
+    end subroutine modify_dertype_fixed_shape_arrays
+
+    subroutine return_dertype_pointer_arrays(m, n, dertype)
+        use datatypes, only: pointer_arrays
+        INTEGER, INTENT(in) :: m, n
+        TYPE(pointer_arrays), INTENT(out) :: dertype
+        REAL(idp), DIMENSION(:,:), ALLOCATABLE, TARGET :: chi
+        INTEGER :: i, j
+
+        ALLOCATE(chi(m,n))
+        dertype%chi => chi
+        dertype%chi(:,:) = 100.0_idp
+        dertype%chi(m-2,n-1) = -10.0_idp
+    end subroutine return_dertype_pointer_arrays
+
+!    subroutine modify_dertype_pointer_arrays(dertype)
+!        use datatypes, only: pointer_arrays
+!        TYPE(pointer_arrays), INTENT(inout) :: dertype
+!        INTEGER :: i, j, m, n
+!        m = dertype%chi_shape(1)
+!        n = dertype%chi_shape(2)
+!        dertype%chi(:,:) = dertype%chi(:,:)*dertype%chi(:,:)
+!        dertype%chi(m-2, n-1) = -9.0_idp
+!    end subroutine modify_dertype_pointer_arrays
+
+   subroutine return_dertype_alloc_arrays(m, n, dertype)
+        use datatypes_allocatable, only: alloc_arrays
+        INTEGER, INTENT(in) :: m, n
+        TYPE(alloc_arrays), INTENT(out) :: dertype
+        INTEGER :: i,j
+
+        ALLOCATE(dertype%chi(m,n))
+        dertype%chi(:,:) = 10.0_idp
+        dertype%chi(m-2,n-1) = -1.0_idp
+    end subroutine return_dertype_alloc_arrays
+
+    subroutine modify_dertype_alloc_arrays(dertype)
+        use datatypes_allocatable, only: alloc_arrays
+        TYPE(alloc_arrays), INTENT(inout) :: dertype
+        INTEGER :: i, j, m, n
+        m = dertype%chi_shape(1)
+        n = dertype%chi_shape(2)
+        dertype%chi(:,:) = dertype%chi(:,:)*dertype%chi(:,:)
+        dertype%chi(m-2, n-1) = -9.0_idp
+    end subroutine modify_dertype_alloc_arrays
+
+    ! Python bindings for this subroutine doesn't work either because of a
+    ! pointer/allocator argument
+    subroutine return_array_nested(dt_array)
+
+        use datatypes, only: array_nested, different_types, fixed_shape_arrays
+        use datatypes_allocatable, only: alloc_arrays
+
+        type(array_nested), INTENT(out), DIMENSION(:), ALLOCATABLE :: dt_array
+        type(array_nested) :: dt, dt_tmp
+        type(different_types) :: xi
+        type(fixed_shape_arrays) :: omicron
+        type(alloc_arrays) :: pi
+        INTEGER :: i
+
+        ! type(different_types), DIMENSION(:), ALLOCATABLE :: xi
+        ! type(fixed_shape_arrays), DIMENSION(:), ALLOCATABLE :: omicron
+        ! type(alloc_arrays), DIMENSION(:), ALLOCATABLE :: pi
+
+        if (allocated(dt_array)) deallocate(dt_array)
+        allocate(dt_array(3))
+
+        do i=1,3
+            dt = dt_array(i)
+            dt%xi%beta = 2*i
+            dt%xi%delta = 2*i
+        end do
+
+    end subroutine return_array_nested
+
+!    subroutine modify_dertype_pointer_arrays(dertype)
+!        use datatypes, only: pointer_arrays
+!        TYPE(pointer_arrays), INTENT(inout), POINTER :: dertype
+!!        REAL(idp), DIMENSION(:,:), ALLOCATABLE :: kappa
+!!        REAL(idp), DIMENSION(:,:), POINTER :: lambda
+!        INTEGER :: i,j,m,n
+!        REAL(idp) :: tmp_idp
+
+!        n = 12
+!        m = 4
+!        ! create the new vector and give it some values
+!!        if (allocated(kappa)   deallocate(kappa)
+!        ALLOCATE(dertype%kappa(n,m))
+!        DO i=1,n
+!            DO j=1,m
+!                ! for the sake of the example, convert to a float
+!                tmp_idp = TRANSFER(i*j, tmp_idp)
+!                dertype%kappa(i,j) = tmp_idp
+!            ENDDO
+!        ENDDO
+!        dertype%lambda => dertype%kappa
+!    end subroutine modify_dertype_pointer_arrays
+
+end module library
+

--- a/examples/example-derivedtypes/memory_profile.py
+++ b/examples/example-derivedtypes/memory_profile.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import numpy as np
+
+import ExampleArray as lib
+
+@profile
+def do_array_stuff(ndata):
+    xdata = np.arange(ndata)
+    fdata = np.arange(ndata)
+    breakarr = np.zeros((ndata,), order='F', dtype=np.float64)
+    cscoef = np.zeros((4, ndata), order='F', dtype=np.float64)
+
+    lib.library.do_array_stuff(n=ndata, x=xdata, y=fdata,
+                               br=breakarr, co=cscoef)
+
+    cscoef_np = np.zeros((4, ndata), order='F', dtype=np.float64)
+    for k in range(4):
+        cscoef_np[k,:] = xdata*fdata + xdata
+    breakarr_np = np.zeros((ndata), order='F', dtype=np.float64)
+    breakarr_np[:] = xdata/(fdata+1.0)
+
+    print(np.allclose(breakarr_np, breakarr))
+    print(np.allclose(cscoef_np, cscoef))
+    p2 = breakarr
+
+    lib.library.only_manipulate(n=ndata, array=cscoef)
+    p3 = cscoef
+
+do_array_stuff(1e6)

--- a/examples/example-derivedtypes/parameters.f90
+++ b/examples/example-derivedtypes/parameters.f90
@@ -1,0 +1,13 @@
+module parameters
+
+implicit none
+private
+public :: idp, isp
+
+INTEGER, PARAMETER :: idp=kind(1d0) ! double precision, np.float64 equivalent
+INTEGER, PARAMETER :: isp=kind(1e0) ! single precision, np.float32 equivalent
+
+contains
+
+end module parameters
+

--- a/examples/example-derivedtypes/tests.py
+++ b/examples/example-derivedtypes/tests.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import ExampleDerivedTypes
+import ExampleDerivedTypes_pkg
+
+
+class BaseTests(object):
+
+    def setUp(self):
+        pass
+
+    def test_return_value_func(self):
+        val_in = 100
+        val_out = self.lib.library.return_value_func(val_in)
+        self.assertEqual(val_in+10, val_out)
+
+    def test_return_value_sub(self):
+        val_in = 100
+        val_out = self.lib.library.return_value_sub(val_in)
+        self.assertEqual(val_in+10, val_out)
+
+    def test_return_a_dt_func(self):
+        dt = self.lib.library.return_a_dt_func()
+        self.assertIsInstance(dt, self.lib.datatypes.Different_Types)
+        self.assertEqual(dt.alpha, 1) # logicals, so 1/0 instead of T/F
+        self.assertEqual(dt.beta, 666)
+        self.assertEqual(dt.delta, 666.666)
+
+    def do_array_stuff(self, ndata, libfunc):
+        x = np.arange(ndata)
+        y = np.arange(ndata)
+        br = np.zeros((ndata,), order='F')
+        co = np.zeros((4, ndata), order='F')
+
+        libfunc(n=ndata, x=x, y=y, br=br, co=co)
+
+        for k in range(4):
+            np.testing.assert_allclose(x*y + x, co[k,:])
+        np.testing.assert_allclose(x/(y+1.0), br)
+
+    def test_smallish_array(self):
+        self.do_array_stuff(1e2, self.lib.library.do_array_stuff)
+
+    def test_verybig_array(self):
+        self.do_array_stuff(1e6, self.lib.library.do_array_stuff)
+
+    def test_only_manipulate(self):
+        n = 1e5
+        x = np.arange(n)
+        y = np.arange(n)
+        br = np.zeros((n,), order='F')
+        co = np.zeros((4, n), order='F')
+
+        self.lib.library.do_array_stuff(n=n, x=x, y=y, br=br, co=co)
+        self.lib.library.only_manipulate(n=n, array=co)
+
+#        self.assertIsInstance(br.dtype.type, np.float64)
+
+        for k in range(4):
+            np.testing.assert_allclose((x*y + x)**2, co[k,:])
+
+    def test_set_derived_type(self):
+
+        dt_beta = 99 # beta is an integer
+        dt_delta = 199.0 # delta is double precision
+
+        dt = self.lib.library.set_derived_type(dt_beta=dt_beta,
+                                               dt_delta=dt_delta)
+        self.assertIsInstance(dt, self.lib.datatypes.Different_Types)
+        self.assertEqual(dt.beta, dt_beta)
+        self.assertEqual(dt.delta, dt_delta)
+
+    def test_modify_derived_types(self):
+
+        dt1 = self.lib.datatypes.Different_Types()
+        dt1.beta = 10
+        dt1.delta = 11.11
+        dt2 = self.lib.datatypes.Different_Types()
+        dt2.beta = 20
+        dt2.delta = 22.22
+        dt3 = self.lib.datatypes.Different_Types()
+        dt3.beta = 30
+        dt3.delta = 33.33
+
+        self.lib.library.modify_derived_types(dt1, dt2, dt3)
+
+        self.assertEqual(dt1.beta, 20)
+        self.assertEqual(dt1.delta, 21.11)
+
+        self.assertEqual(dt2.beta, 40)
+        self.assertEqual(dt2.delta, 42.22)
+
+        self.assertEqual(dt3.beta, 60)
+        self.assertEqual(dt3.delta, 63.33)
+
+    def test_modify_dertype_multiple_arrays(self):
+
+        dt = self.lib.library.modify_dertype_fixed_shape_arrays()
+        self.assertIsInstance(dt, self.lib.datatypes.Fixed_Shape_Arrays)
+
+        self.assertEqual(dt.eta.dtype, np.int32)
+        eta = np.ones((10,4), dtype=np.int)
+        np.testing.assert_array_equal(dt.eta, eta*10)
+
+        # FIXME: Fails because dt.theta is not float32 (single precision)
+        # see test case: test_single_precesion_array
+#        self.assertEqual(dt.theta.dtype, np.float32)
+#        theta = np.ones((10,4), dtype=np.float32)*np.float32(2.0)
+#        np.testing.assert_array_equal(dt.theta, theta)
+
+        self.assertEqual(dt.iota.dtype, np.float64)
+        iota = np.ones((10,4), dtype=np.float64)*np.float64(100.0)
+        np.testing.assert_array_equal(dt.iota, iota)
+
+    # this test will fail because theta is supposed to be single precision
+    @unittest.expectedFailure
+    def test_single_precesion_array(self):
+
+        dt = self.lib.library.modify_dertype_fixed_shape_arrays()
+        self.assertIsInstance(dt, self.lib.datatypes.Fixed_Shape_Arrays)
+
+        # expected failure: dt.theta seems to be float64 (double precision)
+        # while it should be single precision
+        self.assertEqual(dt.theta.dtype, np.float32)
+        theta = np.ones((10,4), dtype=np.float32)
+        np.testing.assert_array_equal(dt.theta, theta*np.float32(2.0))
+
+    def test_nested_dertype(self):
+        ndt = self.lib.datatypes.Nested()
+        self.assertIsInstance(ndt.mu.alpha, int) # boolean/logical in F though
+        self.assertIsInstance(ndt.mu.beta, int)
+        self.assertIsInstance(ndt.mu.delta, float)
+        self.assertIsInstance(ndt.nu, self.lib.datatypes.Fixed_Shape_Arrays)
+
+    # this test will fail because pointer/alloc arrays as arguments are not
+    # supported.
+    @unittest.expectedFailure
+    def test_return_dertype_pointer_arrays(self):
+        m, n = 9, 5
+        dt = self.lib.library.return_dertype_pointer_arrays(m, n)
+        self.assertIsInstance(dt, self.lib.datatypes.Pointer_Arrays)
+        expected = np.ones((m, n), order='F', dtype=np.float64) * 100.0
+        expected[m-3, n-2] = -10.0
+        # it seems dt.chi can not be accessed from Python
+        # expected failure
+        np.testing.assert_allclose(dt.chi, expected)
+
+    def test_return_dertype_alloc_arrays(self):
+        m, n = 9, 5
+        dt = self.lib.library.return_dertype_alloc_arrays(m, n)
+        dt.chi_shape = np.array([m, n], dtype=np.int32)
+        self.assertIsInstance(dt, self.lib.datatypes_allocatable.Alloc_Arrays)
+        expected = np.ones((m, n), order='F', dtype=np.float64) * 10.0
+        expected[m-3, n-2] = -1.0
+        np.testing.assert_allclose(dt.chi, expected)
+
+#    def test_modify_dertype_pointer_arrays(self):
+#
+#        # create an array
+#        dt = self.lib.datatypes.Pointer_Arrays()
+#        m, n = 9, 5
+#        dt.chi = np.mgrid[0:m,0:n][0]
+#        dt.chi_shape = np.array([m,n], dtype=np.int32)
+#        self.lib.library.modify_dertype_pointer_arrays(dt)
+#
+#        expected = np.ones((m, n), order='F', dtype=np.float64) * 81.0
+#        expected[0, 0] = 2500.0
+#        expected[m-3, n-2] = -9.0
+#        np.testing.assert_allclose(dt.chi, expected)
+
+    def test_modify_dertype_alloc_arrays(self):
+
+#        # the array can only be created from Fortran and this will fail
+#        dt = self.lib.datatypes_allocatable.Alloc_Arrays()
+#        dt.chi = np.mgrid[0:9,0:6][0]
+#        dt.chi_shape = np.ndarray([9,6], dtype=np.int32)
+
+        # create an array in Fortran
+        m, n = 9, 5
+        dt = self.lib.library.return_dertype_alloc_arrays(m, n)
+        # the shape of the 2D array is also part of the derived type
+        # so we do not have to pass the shape of the array again when modifying
+        # the those arrays in other subroutines
+        dt.chi_shape = np.array([m, n], dtype=np.int32)
+        # we can also place a new array in here as long as we keep the same
+        # data type
+        dt.chi = np.ndarray((m,n), dtype=np.float64)
+        dt.chi[:,:] = 9.0
+        dt.chi[0,0] = 50.0
+        self.lib.library.modify_dertype_alloc_arrays(dt)
+
+        expected = np.ones((m, n), order='F', dtype=np.float64) * 81.0
+        expected[0, 0] = 2500.0
+        expected[m-3, n-2] = -9.0
+        np.testing.assert_allclose(dt.chi, expected)
+
+#    def test_array_of_dertype(self):
+#        dt = self.lib.datatypes.Array_Nested
+
+    def test_alloc_arrays(self):
+        m, n = 10, 4
+        dt = self.lib.datatypes_allocatable.Alloc_Arrays()
+        self.lib.datatypes_allocatable.init_alloc_arrays(dt, m, n)
+        self.assertEqual(dt.chi.shape, (m,n))
+
+        dt.chi = np.arange(m*n).reshape(m, n)
+
+        def assign_wrong_size():
+            dt.chi = np.arange(m*(n-1)).reshape(m, n-1)
+        self.assertRaises(ValueError, assign_wrong_size)
+
+    def test_nested_alloc_arrays(self):
+        n = 10
+        dt = self.lib.datatypes.Array_Nested()
+        self.lib.datatypes.init_array_nested(dt, n)
+
+        self.assertEqual(len(dt.xi), n)
+        self.assertEqual(len(dt.omicron), n)
+        self.assertEqual(len(dt.pi), n)
+
+
+class LibTests(unittest.TestCase, BaseTests):
+    lib = ExampleDerivedTypes
+
+
+class LibTestsPkg(unittest.TestCase, BaseTests):
+    lib = ExampleDerivedTypes_pkg
+
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
I've been working on another derived type example, that also includes arrays. It also contains pointer/allocatable arrays as arguments to illustrate it is not supported by f90wrap. Since I am only Fortran beginner, it think it would be good if this example could be reviewed. The example comes with a series of tests.

There's one thing I can not figure out why is not working as I think it should: on line [8](https://github.com/jameskermode/f90wrap/compare/master...davidovitch:example-dertype?expand=1#diff-56998375962074e7a89e68fbf1448a60R8) of ```datatypes.f90``` I define a derived type that includes two allocatable arrays in one module. If I try to do exactly the same on line [102](https://github.com/jameskermode/f90wrap/compare/master...davidovitch:example-dertype?expand=1#diff-56998375962074e7a89e68fbf1448a60R8), but there it fails.