### PR TITLE
Example notebook added

### DIFF
--- a/examples/cylinder/DNAD.f90
+++ b/examples/cylinder/DNAD.f90
@@ -110,7 +110,7 @@ MODULE Dual_Num_Auto_Diff
 
 IMPLICIT NONE
 
-INTEGER(2), PUBLIC,PARAMETER:: NDV_AD=3 ! number of design variables
+INTEGER(2), PUBLIC,PARAMETER:: NDV_AD=2 ! number of design variables
 
 PRIVATE
 

--- a/examples/cylinder/cylinder.ipynb
+++ b/examples/cylinder/cylinder.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#Simple example to compute derivatives of any Fortran routine with DNAD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "James C. Orr$^1$, Jean-Marie Epitalon$^2$, and James Kermode$^3$ \n",
+    "\n",
+    "$^1$Laboratoire des Sciences du Climat et de l'Environnement/IPSL, CEA-CNRS-UVSQ, Gif-sur-Yvette, France<br>\n",
+    "$^2$Geoscientific Programming Services, Fanjeax, France<br>\n",
+    "$^3$ Warwick Centre for Predictive Modelling, University of Warwick, UK\n",
+    "\n",
+    "21 September 2015<br>\n",
+    "\n",
+    "<hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do you want to compute derivatives from an existing fortran code simply and accurately? If so, read on.\n",
+    "\n",
+    "There is a simple and accurate way to compute first derivatives from an existing Fortran subroutine with minimal code modification. The method, called Dual Number Automatic Differentiation (DNAD), is described by\n",
+    "<a href=\"./Yu_Blair_2013_CompPhysComm.pdf\">Yu and Blair (2013)</a>. The DNAD approach yields derivatives $\\partial y_j / \\partial x_i$, where $x_i$ are all input variables ($i = 1,n$) and $y_j$ are all output variables ($j = 1,m$).\n",
+    "\n",
+    "To do compute the derivatives, one simply needs to change the TYPE definition of the variables (and import the DNAD module). Results are as accurate as the analytical solution, i.e., to machine precision.\n",
+    "\n",
+    "For this little demo, we first wrapped the fortran routines in `f90wrap` to access them in python. To do that, just download the files in the same directory where you found this Jupyter notebook file, and then type `make`. Then just execute the cells below, where we show how to run the wrapped code in python.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Specify working directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Working directory (change as needed) \n",
+    "#cylynder_dnad_dir = \"/home/my-user-name/etc/\"\n",
+    "cylynder_dnad_dir = \".\"\n",
+    "import sys\n",
+    "sys.path.append(cylynder_dnad_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use print() from Python3 instead of print from Python2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "####Import `numpy` and the fortran routines (including the `cylinder` demo and the `DNAD` module) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import Example # or Example_pkg, as you prefer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "####Specify definitions to use later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Some definitions for later use (thanks to James Kermode)\n",
+    "d1 = Example.Dual_Num_Auto_Diff.Dual_Num()\n",
+    "d2 = Example.Dual_Num_Auto_Diff.Dual_Num()\n",
+    "d3 = Example.Mcyldnad.cyldnad(d1, d2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "####Some documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "        vol = cyldnad(radius, height)\n",
+      "        \n",
+      "        \n",
+      "        Defined at cyldnad.fpp lines 8-16\n",
+      "        \n",
+      "        Parameters\n",
+      "        ----------\n",
+      "        radius : Dual_Num\n",
+      "        height : Dual_Num\n",
+      "        \n",
+      "        Returns\n",
+      "        -------\n",
+      "        vol : Dual_Num\n",
+      "        \n",
+      "        \n"
+     ]
+    }
+   ],
+   "source": [
+    "cylin=Example.Mcyldnad.cyldnad\n",
+    "print(cylin.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Initialize d1 and d2 variables, each of the type dual_num (defined in the `DNAD` module):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "d1: <dual_num>{\n",
+      "    x_ad_ : 3.0,\n",
+      "    xp_ad_ : array([ 1.,  0.])}\n",
+      "d2: <dual_num>{\n",
+      "    x_ad_ : 5.0,\n",
+      "    xp_ad_ : array([ 0.,  1.])}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specify radius (r)\n",
+    "d1.x_ad_ = 3\n",
+    "# Specify that we want dv/dr, where v is cylinder volume and r is cylinder radius\n",
+    "d1.xp_ad_ =np.array((1.,0.))\n",
+    "print(\"d1:\", d1)\n",
+    "\n",
+    "# Specify height (h)\n",
+    "d2.x_ad_ = 5\n",
+    "# Specify that we want dv/dh, where h is cylinder height\n",
+    "d2.xp_ad_ = np.array((0,1.))\n",
+    "print(\"d2:\", d2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run subroutine \"cylinder\" to compute volume $v$, $dv/dr$, and $dv/dh$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "result: <dual_num>{\n",
+      "    x_ad_ : 141.3716694115407,\n",
+      "    xp_ad_ : array([ 94.24777961,  28.27433388])}\n"
+     ]
+    }
+   ],
+   "source": [
+    "d3 = Example.Mcyldnad.cyldnad(d1, d2)\n",
+    "# Print computed v, dv/dr, dv/dh (thanks to dual numbers)\n",
+    "print(\"result:\", d3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
James,
Here are a couple of small items for the cylinder example
- Added a Jupyter notebook for a demo of how to use 'cyldnad.f90' in python.
- Also fixed parameter in DNAD.f90 so that it would treat 2 input variables (instead of 3).

James