### PR TITLE
added example with character strings

### DIFF
--- a/examples/example-charstrings/Makefile
+++ b/examples/example-charstrings/Makefile
@@ -1,0 +1,139 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+PYTHON   = python2
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = ExampleCharStrings
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = stringutils
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = stringutils
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
+
+
+clean:
+	-rm ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}.so \
+	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
+
+
+test:
+	${PYTHON} tests.py
+

--- a/examples/example-charstrings/README.md
+++ b/examples/example-charstrings/README.md
@@ -1,0 +1,39 @@
+example-charstrings
+===================
+
+Because of differences between Fortran and C alike strings and characters it
+is not straight forward to exchange (long) strings between Fortran routines
+and Python. This example shows a workaround for ASCII characters which are
+first converted to integers in Python, and back to characters in Fortran.
+
+Simple example with a wrapped subroutines that convert an integer array
+representing ASCII characters to a character array and string (character*) in
+Fortran.
+
+For inspiration, alternative methods could be based on:
+
+* <https://gcc.gnu.org/onlinedocs/gfortran/Interoperable-Subroutines-and-Functions.html>
+* <http://stackoverflow.com/questions/22620643/how-to-bind-cs-char-argument-in-fortran>
+* <http://stackoverflow.com/questions/9686532/arrays-of-strings-in-fortran-c-bridges-using-iso-c-binding>
+* <http://stackoverflow.com/questions/22293180/passing-numpy-string-format-arrays-to-fortran-using-f2py>
+
+To build and wrap with f90wrap, use the included ```Makefile```:
+
+```
+make
+```
+
+and before rebuilding, clean-up with:
+
+```
+make clean
+```
+
+A simple unittests are included in ```tests.py```.
+
+
+Author
+------
+
+David Verelst: <david.Verelst@gmail.com>
+

--- a/examples/example-charstrings/kind_map
+++ b/examples/example-charstrings/kind_map
@@ -1,0 +1,18 @@
+{
+ 'real':     {   '' : 'float',
+                '4' : 'float',
+              'isp' : 'float',
+                '8' : 'double',
+               'dp' : 'double',
+              'idp' : 'double'},
+ 'complex' : {   '' : 'complex_float',
+ 	            '8' : 'complex_double',
+ 	           '16' : 'complex_long_double',
+ 	           'dp' : 'complex_double'},
+ 'integer' : {  '4' : 'int',
+	            '8' : 'long_long',
+	           'dp' : 'long_long' },
+ 'character' : {''  : 'char',
+                '1': 'char'}
+}
+

--- a/examples/example-charstrings/stringutils.f90
+++ b/examples/example-charstrings/stringutils.f90
@@ -1,0 +1,124 @@
+module stringutils
+
+    implicit none
+    private
+    public :: testing_chararray, testing_intarray, roundtrip, chararray_roundtrip
+    public :: fill_global_string
+
+    CHARACTER(512) long_global_string
+
+contains
+
+    function chararray2string(n, chararray) result(string)
+        INTEGER(4) i, j, n
+        CHARACTER(n) string
+        CHARACTER(1), DIMENSION(n) :: chararray
+        DO i=1,n
+            j = i + 1
+            string(i:j) = chararray(i)
+        ENDDO
+    end function chararray2string
+
+    function string2chararray(n, string) result(chararray)
+        INTEGER(4) i, j, n
+        CHARACTER(n) string
+        CHARACTER(1), DIMENSION(n) :: chararray
+        DO i=1,n
+            j = i + 1
+            chararray(i) = string(i:j)
+        ENDDO
+    end function string2chararray
+
+    function string2intarray(n, string) result(intarray)
+        INTEGER(4) i, j, n
+        CHARACTER(n) string
+        INTEGER(4), DIMENSION(n) :: intarray
+        DO i=1,n
+            j = i + 1
+            intarray(i) = ichar(string(i:j))
+        ENDDO
+    end function string2intarray
+
+    function intarray2string(n, intarray) result(string)
+        INTEGER(4) n, i, j
+        INTEGER(4), DIMENSION(n) :: intarray
+        CHARACTER(n) string
+        DO i=1,n
+            j = i + 1
+            string(i:j) = achar(intarray(i))
+        ENDDO
+    end function intarray2string
+
+    function chararray2intarray(n, chararray) result(intarray)
+        INTEGER(4) i, n
+        INTEGER(4), DIMENSION(n) :: intarray
+        CHARACTER(1), DIMENSION(n) :: chararray
+        DO i=1,n
+            intarray(i) = ichar(chararray(i))
+        ENDDO
+    end function chararray2intarray
+
+    function intarray2chararray(n, intarray) result(chararray)
+        INTEGER(4) i, n
+        INTEGER(4), DIMENSION(n) :: intarray
+        CHARACTER(1), DIMENSION(n) :: chararray
+        DO i=1,n
+            chararray(i) = achar(intarray(i))
+        ENDDO
+    end function intarray2chararray
+
+    subroutine chararray_roundtrip(n, chararray, chararray_out)
+        INTEGER(4), INTENT(in) :: n
+        CHARACTER, DIMENSION(n), INTENT(in) :: chararray
+        CHARACTER, DIMENSION(n), INTENT(inout) :: chararray_out
+        CHARACTER(n) string
+        string = chararray2string(n, chararray)
+        print*,"PRINT string: ", string
+        write(*,*) "WRITE string: ", string
+        chararray_out = string2chararray(n, string)
+    end subroutine chararray_roundtrip
+
+    subroutine testing_chararray(n, chararray)
+        INTEGER(4), INTENT(in) :: n
+        CHARACTER(1), DIMENSION(n), INTENT(in):: chararray
+        CHARACTER(n) :: string
+        string = chararray2string(n, chararray)
+        write(*,*) "constructed string (between commas): ,", string, ","
+    end subroutine testing_chararray
+
+    subroutine testing_intarray(n, intarray)
+        INTEGER(4), INTENT(in) :: n
+        INTEGER(4), DIMENSION(n), INTENT(in):: intarray
+        CHARACTER(n) :: string
+        string = intarray2string(n, intarray)
+        write(*,*) "constructed string (between commas): ,", string, ","
+    end subroutine testing_intarray
+
+    subroutine roundtrip(n, intarray, intarray_out)
+        INTEGER(4), INTENT(in) :: n
+        INTEGER(4), DIMENSION(n), INTENT(in):: intarray
+        INTEGER(4), DIMENSION(n), INTENT(out):: intarray_out
+        CHARACTER(1), DIMENSION(n) :: chararray
+        CHARACTER(n) :: string
+        string = intarray2string(n, intarray)
+        chararray = string2chararray(n, string)
+        intarray_out = chararray2intarray(n, chararray)
+    end subroutine roundtrip
+
+    subroutine fill_global_string(n, intarray)
+        INTEGER(4), INTENT(in) :: n
+        INTEGER(4), DIMENSION(n), INTENT(in):: intarray
+        CHARACTER(n) :: string
+
+        string = intarray2string(n, intarray)
+        write(*,*) "constructed string (between commas): ,", string, ","
+
+        long_global_string = string
+        write(*,*) "long_global_string (between commas): ,", long_global_string, ","
+
+        long_global_string = long_global_string(1:n)
+        write(*,*) "long_global_string(1:n) (between commas): ,", long_global_string, ","
+    end subroutine fill_global_string
+
+end module stringutils
+

--- a/examples/example-charstrings/tests.py
+++ b/examples/example-charstrings/tests.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import ExampleCharStrings
+import ExampleCharStrings_pkg
+
+
+class BaseTests(object):
+
+    text = '-_-::this is a string with ASCII, / and 123...::-_-'
+    intarray = np.array([ord(k) for k in list(text)], dtype=np.int32)
+    chararray = np.array([k for k in list(text)], dtype='c')
+    n = len(text)
+
+    def test_roundtrip(self):
+        intarray_out = np.ndarray((len(self.text),), dtype=np.int32)
+        self.lib.roundtrip(len(self.text), self.intarray, intarray_out)
+        np.testing.assert_equal(intarray_out, self.intarray)
+
+    # test will fail because passing character arrays like this does not work
+    # expectedFailure only added to unittest module in Python 2.7
+#    @unittest.expectedFailure
+#    def test_chararray(self):
+#        self.lib.testing_chararray(self.n, self.chararray)
+
+    def test_intarray(self):
+        self.lib.testing_intarray(self.n, self.intarray)
+
+    # test will fail because passing character arrays like this does not work
+    # expectedFailure only added to unittest module in Python 2.7
+#    @unittest.expectedFailure
+#    def test_chararray_output(self):
+#        chararray_out = self.lib.intarray2chararray(self.n, self.intarray)
+
+    # test will fail because passing character arrays like this does not work
+    # expectedFailure only added to unittest module in Python 2.7
+#    @unittest.expectedFailure
+#    def test_chararray_roundtrip(self):
+#        chararray_out = np.ndarray((self.n,), dtype='c')
+#        self.lib.chararray_roundtrip(self.n, self.chararray, chararray_out)
+
+    def test_fill_global_string(self):
+        self.lib.fill_global_string(self.n, self.intarray)
+
+
+class LibTests(unittest.TestCase, BaseTests):
+    lib = ExampleCharStrings.stringutils
+
+
+class LibTestsPkg(unittest.TestCase, BaseTests):
+    lib = ExampleCharStrings_pkg.stringutils
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have been trying to figure out how to pass strings (holding multiple characters) between Fortran and Python (and visa versa), but I did not manage to find a nice and clean solution. Instead, I created a workaround in which I pass on an integer array holding the ASCII numerical values to a Fortran subroutine. In Fortran, the integers are converted to either a character array or a string. In case someone knows of a more elegant way, please let me know :-)