### PR TITLE
added simple example for passing along strings/characters

### DIFF
--- a/examples/example-strings/Makefile
+++ b/examples/example-strings/Makefile
@@ -1,0 +1,139 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+PYTHON   = python2
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = ExampleStrings
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = string_io
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = string_io
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
+
+
+clean:
+	-rm ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}.so \
+	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
+
+
+test:
+	${PYTHON} tests.py
+

--- a/examples/example-strings/README.md
+++ b/examples/example-strings/README.md
@@ -1,0 +1,25 @@
+example-strings
+===================
+
+When excluding the character/char mapping in ```kind_map```, strings can be
+passed between Fortran and Python in a straightforward manner.
+
+To build and wrap with f90wrap, use the included ```Makefile```:
+
+```
+make
+```
+
+and before rebuilding, clean-up with:
+
+```
+make clean
+```
+
+Simple unittests are included in ```tests.py```.
+
+
+Author
+------
+
+David Verelst: <david.verelst@gmail.com>

--- a/examples/example-strings/kind_map
+++ b/examples/example-strings/kind_map
@@ -1,0 +1,16 @@
+{
+ 'real':     {   '' : 'float',
+                '4' : 'float',
+              'isp' : 'float',
+                '8' : 'double',
+               'dp' : 'double',
+              'idp' : 'double'},
+ 'complex' : {   '' : 'complex_float',
+ 	            '8' : 'complex_double',
+ 	           '16' : 'complex_long_double',
+ 	           'dp' : 'complex_double'},
+ 'integer' : {  '4' : 'int',
+	            '8' : 'long_long',
+	           'dp' : 'long_long' }
+}
+

--- a/examples/example-strings/string_io.f90
+++ b/examples/example-strings/string_io.f90
@@ -1,0 +1,57 @@
+module string_io
+
+    implicit none
+
+    CHARACTER(512) global_string
+
+contains
+
+    function func_generate_string(n) result(stringout)
+        INTEGER(4) i, j, n, k
+        CHARACTER(n) stringout
+        DO i=1,n
+            j = i + 1
+            k = i + 33
+            stringout(i:j) = achar(k)
+        ENDDO
+    end function func_generate_string
+
+    function func_return_string() result(stringout)
+        CHARACTER(51) stringout
+        stringout = '-_-::this is a string with ASCII, / and 123...::-_-'
+    end function func_return_string
+
+    subroutine generate_string(n, stringout)
+        INTEGER(4) i, j, k
+        INTEGER(4), INTENT(in) :: n
+        CHARACTER(n), INTENT(out) :: stringout
+        DO i=1,n
+            j = i + 1
+            k = i + 33
+            stringout(i:j) = achar(k)
+        ENDDO
+    end subroutine generate_string
+
+    subroutine return_string(stringout)
+        CHARACTER(51), INTENT(out) :: stringout
+        stringout = '-_-::this is a string with ASCII, / and 123...::-_-'
+    end subroutine return_string
+
+    subroutine set_global_string(n, newstring)
+        INTEGER(4), INTENT(in) :: n
+        CHARACTER(n), INTENT(in) :: newstring
+        global_string = newstring
+    end subroutine set_global_string
+
+    subroutine inout_string(n, stringinout)
+        INTEGER(4) i, j
+        INTEGER(4), INTENT(in) :: n
+        CHARACTER(n), INTENT(inout) :: stringinout
+        DO i=1,n
+            j = i + 1
+            stringinout(i:j) = 'Z'
+        ENDDO
+    end subroutine inout_string
+
+end module string_io
+

--- a/examples/example-strings/tests.py
+++ b/examples/example-strings/tests.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import unittest
+
+
+import ExampleStrings
+import ExampleStrings_pkg
+
+
+def generate_string(n):
+    return ''.join([chr(k) for k in range(34,n+34)])
+
+
+class BaseTests(object):
+
+    text = '-_-::this is a string with ASCII, / and 123...::-_-'
+    n = len(text)
+
+    def test_func_generate_string(self):
+        outstring = self.lib.func_generate_string(self.n)
+        self.assertEqual(outstring[:self.n], generate_string(self.n))
+
+    def test_func_return_string(self):
+        outstring = self.lib.func_return_string()
+        self.assertEqual(outstring[:self.n], self.text)
+
+    def test_generate_string(self):
+        outstring = self.lib.generate_string(self.n)
+        self.assertEqual(outstring[:self.n], generate_string(self.n))
+
+    def test_return_string(self):
+        outstring = self.lib.return_string()
+        self.assertEqual(outstring[:self.n], self.text)
+
+    def test_set_global_string(self):
+        self.lib.set_global_string(self.n, self.text)
+        self.assertEqual(self.lib.global_string[:self.n], self.text)
+
+    # string on an inout variable does not work
+    # expectedFailure only added to unittest module in Python 2.7
+#    @unittest.expectedFailure
+#    def test_inout_string(self):
+#        stringio = ' '*self.n
+#        stringio = self.lib.inout_string(self.n, stringio)
+#        self.assertEqual(stringio, 'Z'*self.n)
+
+
+class LibTests(unittest.TestCase, BaseTests):
+    lib = ExampleStrings.string_io
+
+
+class LibTestsPkg(unittest.TestCase, BaseTests):
+    lib = ExampleStrings_pkg.string_io
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A simple example showing how to pass strings/characters. For the record, a too convoluted approach was used in PR #28 (with strings being converted to ascii integers and back). The method shown here is, hopefully, clean and simple.

There are two small things though:
* When importing from ```ExampleStrings_pkg``` the test ```test_set_global_string()``` fails (too many input arguments). When importing from ```ExampleStrings``` it works fine.
* There's something I am not sure about regarding the length of the strings that come back from Fortran, they are longer then I expect. Is there something obvious I am missing?