### PR TITLE
minor changes to parser for fixed formatting code

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,6 @@
 EXAMPLES = mockderivetype example2 arrays derivedtypes \
-	cylinder elemental passbyreference strings type_bn interface
+	cylinder elemental passbyreference strings type_bn interface \
+	arrays_fixed
 
 test:
 	for example in ${EXAMPLES}; do \

--- a/examples/arrays_fixed/Makefile
+++ b/examples/arrays_fixed/Makefile
@@ -1,0 +1,140 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = ExampleArray
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = parameters library
+
+# file names
+LIBSRC_FILES = $(addsuffix .f,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = library
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
+
+
+clean:
+	-rm ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}.so \
+	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f f90wrap*.o *.o
+
+
+.f.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
+
+
+test: _${PYTHON_MODN}_pkg.so _${PYTHON_MODN}.so 
+	${PYTHON} tests.py
+

--- a/examples/arrays_fixed/README.md
+++ b/examples/arrays_fixed/README.md
@@ -1,0 +1,36 @@
+example-arrays
+==============
+
+Simple example with a wrapped subroutine that contains input and output arrays.
+It simply shows how to access and  interact with an array that is being
+initiated in Python, and manipulated by a Fortran subroutine.
+
+This example has been tested with ```gfortran``` and ```ifort``` on Linux 64bit.
+
+To build and wrap with f90wrap, use the included ```Makefile```:
+
+```
+make
+```
+
+and before rebuilding, clean-up with:
+
+```
+make clean
+```
+
+A simple unittest is included in ```tests.py```.
+
+A sample memory profiling script is included in ```memory_profile.py```.
+To profile, run:
+
+```
+python2 -m memory_profiler memory_profile.py
+```
+
+
+Author
+------
+
+David Verelst: <david.Verelst@gmail.com>
+

--- a/examples/arrays_fixed/kind_map
+++ b/examples/arrays_fixed/kind_map
@@ -1,0 +1,14 @@
+{
+ 'real':     {'': 'float',
+              '8': 'double',
+              'dp': 'double',
+              'idp':'double'},
+ 'complex' : {'': 'complex_float',
+ 	          '8' : 'complex_double',
+ 	          '16': 'complex_long_double',
+ 	          'dp': 'complex_double'},
+ 'integer' : {'4': 'int',
+	          '8': 'long_long',
+	          'dp': 'long_long' },
+ 'character' : {'': 'char'}
+}

--- a/examples/arrays_fixed/library.f
+++ b/examples/arrays_fixed/library.f
@@ -1,0 +1,52 @@
+      module library
+
+      use parameters, only: idp, isp
+      implicit none
+      private
+      public :: do_array_stuff, only_manipulate, return_array
+
+      contains
+
+      subroutine do_array_stuff(n,
+     &                          x,y,br,co)
+c-----------------------------------------------------------------------
+      INTEGER, INTENT(in) :: n
+      REAL(kind=idp), INTENT(in) :: x(n)
+      REAL(kind=idp), INTENT(in) :: y(n)
+      REAL(kind=idp), INTENT(out) :: br(n)
+      REAL(kind=idp), INTENT(out) :: co(4,n)
+
+      INTEGER :: i,j
+      DO j=1,n
+          br(j) =  x(j) / ( y(j) + 1.0_idp )
+          DO i=1,4
+              co(i,j) = x(j)*y(j) + x(j)
+          ENDDO
+      ENDDO
+      end subroutine do_array_stuff
+
+      subroutine only_manipulate(n,array)
+      INTEGER, INTENT(in) :: n
+      REAL(kind=idp), INTENT(inout) :: array(4,n)
+
+      INTEGER :: i,j
+      DO j=1,n
+          DO i=1,4
+              array(i,j) = array(i,j)*array(i,j)
+          ENDDO
+      ENDDO
+      end subroutine only_manipulate
+
+      subroutine return_array(m, n, output)
+      INTEGER, INTENT(in) :: m, n
+      INTEGER, INTENT(out) :: output(m,n)
+      INTEGER :: i,j
+      DO i=1,m
+          DO j=1,n
+              output(i,j) = i*j + j
+          ENDDO
+      ENDDO
+      end subroutine return_array
+
+      end module library
+

--- a/examples/arrays_fixed/memory_profile.py
+++ b/examples/arrays_fixed/memory_profile.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import numpy as np
+
+import ExampleArray as lib
+
+@profile
+def do_array_stuff(ndata):
+    xdata = np.arange(ndata)
+    fdata = np.arange(ndata)
+    breakarr = np.zeros((ndata,), order='F', dtype=np.float64)
+    cscoef = np.zeros((4, ndata), order='F', dtype=np.float64)
+
+    lib.library.do_array_stuff(n=ndata, x=xdata, y=fdata,
+                               br=breakarr, co=cscoef)
+
+    cscoef_np = np.zeros((4, ndata), order='F', dtype=np.float64)
+    for k in range(4):
+        cscoef_np[k,:] = xdata*fdata + xdata
+    breakarr_np = np.zeros((ndata), order='F', dtype=np.float64)
+    breakarr_np[:] = xdata/(fdata+1.0)
+
+    print(np.allclose(breakarr_np, breakarr))
+    print(np.allclose(cscoef_np, cscoef))
+    p2 = breakarr
+
+    lib.library.only_manipulate(n=ndata, array=cscoef)
+    p3 = cscoef
+
+do_array_stuff(1e6)

--- a/examples/arrays_fixed/parameters.f
+++ b/examples/arrays_fixed/parameters.f
@@ -1,0 +1,13 @@
+      module parameters
+
+      implicit none
+      private
+      public :: idp, isp
+
+      INTEGER, PARAMETER :: idp=kind(1d0)
+      INTEGER, PARAMETER :: isp=kind(1e0)
+
+      contains
+
+      end module parameters
+

--- a/examples/arrays_fixed/tests.py
+++ b/examples/arrays_fixed/tests.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import ExampleArray as lib
+
+
+class TestExample(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def do_array_stuff(self, ndata):
+        x = np.arange(ndata)
+        y = np.arange(ndata)
+        br = np.zeros((ndata,), order='F')
+        co = np.zeros((4, ndata), order='F')
+
+        lib.library.do_array_stuff(n=ndata, x=x, y=y, br=br, co=co)
+
+        for k in range(4):
+            np.testing.assert_allclose(x*y + x, co[k,:])
+        np.testing.assert_allclose(x/(y+1.0), br)
+
+    def test_basic(self):
+        self.do_array_stuff(1000)
+
+    def test_verybig_array(self):
+        self.do_array_stuff(1000000)
+
+    def test_square(self):
+        n = 100000
+        x = np.arange(n, dtype=float)
+        y = np.arange(n, dtype=float)
+        br = np.zeros((n,), order='F')
+        co = np.zeros((4, n), order='F')
+
+        lib.library.do_array_stuff(n=n, x=x, y=y, br=br, co=co)
+        lib.library.only_manipulate(n=n, array=co)
+        for k in range(4):
+            np.testing.assert_allclose((x*y + x)**2, co[k,:])
+
+    def test_return_array(self):
+        m, n = 10, 4
+        arr = np.ndarray((m,n), order='F', dtype=np.int32)
+        lib.library.return_array(m, n, arr)
+        ii, jj = np.mgrid[0:m,0:n]
+        ii += 1
+        jj += 1
+        np.testing.assert_equal(ii*jj + jj, arr)
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -44,10 +44,10 @@ from f90wrap.fortran import *
 # Define some regular expressions
 
 module = re.compile('^module', re.IGNORECASE)
-module_end = re.compile('^end\s*module', re.IGNORECASE)
+module_end = re.compile('^end\s*module|end$', re.IGNORECASE)
 
 program = re.compile('^program', re.IGNORECASE)
-program_end = re.compile('^end\s*program', re.IGNORECASE)
+program_end = re.compile('^end\s*program|end$', re.IGNORECASE)
 
 attribs = r'allocatable|pointer|save|dimension *\(.*?\)|parameter|target|public|private|extends *\(.*?\)'  # jrk33 added target
 
@@ -70,11 +70,11 @@ iface = re.compile('^interface', re.IGNORECASE)
 iface_end = re.compile('^end\s*interface', re.IGNORECASE)
 
 subt = re.compile(r'^(recursive\s+)?subroutine', re.IGNORECASE)
-subt_end = re.compile(r'^end\s*subroutine\s*(\w*)', re.IGNORECASE)
+subt_end = re.compile(r'^end\s*subroutine\s*(\w*)|end$', re.IGNORECASE)
 
 funct = re.compile('^((' + types + r')\s+)*function', re.IGNORECASE)
 # funct       = re.compile('^function',re.IGNORECASE)
-funct_end = re.compile('^end\s*function\s*(\w*)', re.IGNORECASE)
+funct_end = re.compile('^end\s*function\s*(\w*)|end$', re.IGNORECASE)
 
 prototype = re.compile(r'^module procedure ([a-zA-Z0-9_,\s]*)')
 
@@ -692,7 +692,7 @@ def check_subt(cl, file, grab_hold_doc=True):
             if m == None:
                 cl = file.next()
                 continue
-            elif m.group(1).lower() == out.name.lower() or m.group(1) == '':
+            else:
                 break
 
             # If no joy, get next line
@@ -881,7 +881,7 @@ def check_funct(cl, file, grab_hold_doc=True):
                 cl = file.next()
                 continue
 
-            elif m.group(1).lower() == out.name.lower() or m.group(1) == '':
+            else:
                 break
 
             cl = file.next()

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -282,7 +282,6 @@ class F90File(object):
         if cline == '':
             return None
         else:
-            print 'RETURN', cline
             return cline
 
 

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -52,7 +52,7 @@ program_end = re.compile('^end\s*program|end$', re.IGNORECASE)
 attribs = r'allocatable|pointer|save|dimension *\(.*?\)|parameter|target|public|private|extends *\(.*?\)'  # jrk33 added target
 
 type_re = re.compile(r'^type((,\s*(' + attribs + r')\s*)*)(::)?\s*(?!\()', re.IGNORECASE)
-type_end = re.compile('^end\s*type', re.IGNORECASE)
+type_end = re.compile('^end\s*type|end$', re.IGNORECASE)
 
 dummy_types_re = re.compile('recursive|pure|elemental', re.IGNORECASE)
 
@@ -67,7 +67,7 @@ whitespace = re.compile(r'^\s*')  # Initial whitespace
 c_ret = re.compile(r'\r')
 
 iface = re.compile('^interface', re.IGNORECASE)
-iface_end = re.compile('^end\s*interface', re.IGNORECASE)
+iface_end = re.compile('^end\s*interface|end$', re.IGNORECASE)
 
 subt = re.compile(r'^(recursive\s+)?subroutine', re.IGNORECASE)
 subt_end = re.compile(r'^end\s*subroutine\s*(\w*)|end$', re.IGNORECASE)

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -228,17 +228,37 @@ class F90File(object):
                 pass
             else:
                 cont_index = cline.find('&')
-                comm_index = cline.find('!')
-                while (cont_index != -1 and (comm_index == -1 or comm_index > cont_index)):
-                    cont = cline[:cont_index].strip()
+                try:
                     cont2 = self.lines[1].strip()
                     if cont2.startswith('&'):
-                        cont2 = cont2[1:]
+                        cont2_index = 0
+                    else:
+                        cont2_index = -1
+                except:
+                    cont2_index = -1
+                comm_index = cline.find('!')
+                while (cont_index != -1 and (comm_index == -1 or comm_index > cont_index)) or \
+                      (cont2_index != -1):
+                    if cont_index != -1:
+                        cont = cline[:cont_index].strip()
+                    else:
+                        cont = cline.strip()
+                    cont2 = self.lines[1].strip()
+                    if cont2.startswith('&'):
+                        cont2 = cont2[1:].strip()
                     cont = cont + cont2
                     self.lines = [cont] + self.lines[2:]
                     self._lineno = self._lineno + 1
                     cline = self.lines[0].strip()
                     cont_index = cline.find('&')
+                    try:
+                        cont2 = self.lines[1].strip()
+                        if cont2.startswith('&'):
+                            cont2_index = 0
+                        else:
+                            cont2_index = -1
+                    except:
+                        cont2_index = -1
 
             # split by '!', if necessary
             comm_index = cline.find('!')
@@ -262,6 +282,7 @@ class F90File(object):
         if cline == '':
             return None
         else:
+            print 'RETURN', cline
             return cline
 
 


### PR DESCRIPTION
I've used f90wrap on a large f90 code written with fixed formatting and had to tweak a few things in `parser.py`to get it to work:

* end of programs/routines/functions etc allowed to end with just `end`
* fixed form continuation lines are now handled in the `next` function

This PR does not cover all differences between fixed and free formatting, for example, comments are not caught in `next`. I tried using `regex` with `re.compile('^[^0-9\s]|^\s*!|^c|^C|^\\*')` instead of `find('!')`, but didn't succeed so far. But not catching comments doesn't seem to break anything.

Besides our own code, I've only run f90wrap on the tests which all pass, but please try it on more codes before merging to make sure I didn't screw anything up!