### PR TITLE
Inelegant handling of one fixed dimension arrays of types as arguments 

### DIFF
--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -216,6 +216,10 @@ end type %(typename)s_ptr_type""" % {'typename': tname})
             self.write('%(arg_type)s%(comma)s%(arg_attribs)s :: %(arg_name)s' % arg_dict)
             if hasattr(arg, 'f2py_line'):
                 self.write(arg.f2py_line)
+            elif all('intent' not in attr for attr in arg.attributes):  # add "default to 'inout' option selected" check here
+                # No f2py instruction and no explicit intent : force f2py to make it intent(inout) :
+                self.write('!f2py intent(inout) '+arg.name)
+
 
     def write_transfer_in_lines(self, node):
         """
@@ -709,10 +713,9 @@ end type %(typename)s_ptr_type""" % {'typename': tname})
             else:
                 extra_uses[mod] = [el_tname]
 
-        # If the var that is get/set has the same name as something in uses, then append _
-        localvar = el.name + "_f90wrap"  # Since some cases require a safer localvar name, why not always transform it ?
-        # if localvar in getattr(el, "uses", []) or localvar in extra_uses or localvar == "type":
-        #     localvar += "_"
+        # Prepend prefix to element name
+        #   -- Since some cases require a safer localvar name, we always transform it
+        localvar = self.prefix + el.name
 
         self.write('subroutine %s%s__%s__%s(%s%s)' % (self.prefix, t.name,
                                                     getset, el.name, this, localvar))

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -192,6 +192,15 @@ class Module(Fortran):
             private_symbols = []
         self.private_symbols = private_symbols
 
+    # Required for the Module object to be hashable so one can create sets of Modules
+    # So this function should return a unique imprint of the object
+    # I guess the filename + the module name should be unique enough ?
+    # Also, hash requires an integer, so we convert the string to integers with the
+    # same number of digits to ensure one-to-one conversion.
+    # This is maybe unnecessarily long ?
+    def __hash__(self):
+        return int(''.join(str(ord(x)).zfill(3) for x in self.filename + self.name))
+
 
 class Procedure(Fortran):
     """

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -501,8 +501,8 @@ def check_module(cl, file):
                 # Module variable
                 check = check_decl(cl, file)
                 if check[0] != None:
-                    for a in check[0]:
-                        out.elements.append(a)
+                    for el in check[0]:
+                        out.elements.append(el)
                         cl = check[1]
                     continue
 
@@ -1307,7 +1307,6 @@ def check_arg(cl, file):
             # Append dimension if necessary
             if sizes[i] != '':
                 temp.attributes.append('dimension' + sizes[i])
-
             out.append(temp)
 
         return [out, cl]

--- a/f90wrap/transform.py
+++ b/f90wrap/transform.py
@@ -1126,7 +1126,8 @@ def create_super_types(tree, types):
             append_type_dimension(arg, types)
     # Then create a super-type for each type for each dimension, inside the module where
     # the type is declared in the first place.
-    modules_indexes = {mod.name: i for i, mod in enumerate(tree.modules)}  # name to index map
+    # modules_indexes = {mod.name: i for i, mod in enumerate(tree.modules)}  # name to index map
+    modules_indexes = dict((mod.name, i) for (i, mod) in enumerate(tree.modules))
     containers = []
     for ty in types.values():
         for dim in set(attr for attr in ty.attributes if attr.startswith('dimension')):

--- a/scripts/f90wrap
+++ b/scripts/f90wrap
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/Users/Yann/anaconda/bin/python
 """
 # HF XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # HF X
@@ -122,6 +122,8 @@ USAGE
                             help='Name of Fortran subroutine to invoke if a fatal error occurs')
         parser.add_argument("--only", nargs="*", default=[], help="Subroutines to include in wrapper")
         parser.add_argument("--skip", nargs="*", default=[], help="Subroutines to exclude from wrapper")
+        parser.add_argument('--default-to-inout', action='store_true', default=False,
+                            help="Sets all arguments without intent to intent(inout)")
 
         args = parser.parse_args()
 
@@ -248,7 +250,7 @@ USAGE
                                       kind_map=kind_map,
                                       init_file=args.init_file).visit(py_tree)
         fwrap.F90WrapperGenerator(args.prefix, fsize, string_lengths,
-                                  args.abort_func, kind_map, types).visit(f90_tree)
+                                  args.abort_func, kind_map, types, args.default_to_inout).visit(f90_tree)
         return 0
 
     except KeyboardInterrupt:


### PR DESCRIPTION
- Also a bug fix for the --only option (added __hash()__ function to module class)
- Also added --default-to-inout option to declare all arguments without intent to inout

The arrays of types are handled by creating a super-type containing the fixed size array, as suggested previously. So, type containers (super-types) are created each time an argument is type of one fixed size dimension. The already available routines then create constructors and destructors, making the container usable in python and the call line for the routine is slightly updated.

However, the result is quite cumbersome and very unlikely to be extendable to assumed shape arrays with dimension(:).

I also have written a minimal test example, but do not know how to add a folder to the repository...

