### PR TITLE
Debug control

### DIFF
--- a/examples/fixed_1D_derived_type_array_argument/tests.py
+++ b/examples/fixed_1D_derived_type_array_argument/tests.py
@@ -17,6 +17,16 @@ print(list(d.items[i].y for i in range(len(d.items))))
 print(list(e.items[i].y for i in range(len(e.items))))
 print(f)
 
+# multiple gets, to see if i is modified by the call or not
+i = numpy.ones(1, dtype=int)
+g = b.items[i].y[i]
+g = b.items[i].y[i]
+g = b.items[i].y[i]
+g = b.items[i].y[i]
+g = b.items[i].y[i]
+g = b.items[i].y[i]
+print("g = " + str(g))
+print("i = " + str(i))
 
 assert(all(a == numpy.array([42, 1, 1, 1, 1], dtype=numpy.float32)))
 assert(b.items[1].y[1] == 42)
@@ -24,3 +34,4 @@ assert(c.items[2].y[2] == 42)
 assert(d.items[3].y[3] == 42)
 assert(e.items[4].y[4] == 42)
 assert(f == 2)
+assert(g == 42)


### PR DESCRIPTION
Funny bug :
It is about the functions __getitem__ and __setitem__ of the FortranDerivedTypeArray class, at the very bottom of the fortrantype.py file.
Since python indexing is 0-based and fortran 1-based, a conversion has to be done. However, in the original code, the value of the argument is modified, instead of calling fortran with arg+1. If the argument is passed by reference, the former would modify  the calling index, which is wrong. However, I guess that the issue never presented itself because, when going through fortran, scalar arguments without intent are treated as intent in. But, if the index is declared as an array of length=1, it will be intent(inout), raising the problem.

I updated my fixed_1D_derived_type_array_argument example to test this: with the current code (call i+1) it works, but with the old code (i+=1), and "i" declared as bumpy.ones(1), it fails.