### PR TITLE
Fixes repeated interfaces for linked-list construct

### DIFF
--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -763,7 +763,7 @@ end type %(typename)s_ptr_type""" % {'typename': tname})
         if isinstance(t, ft.Type):
             self.write_type_lines(t.name)
 
-        if el.type.startswith('type'):
+        if el.type.startswith('type') and not (el.type == 'type('+t.name+')'):
             self.write_type_lines(el.type)
 
         if isinstance(t, ft.Type):


### PR DESCRIPTION
Applying f90wrap to this little test module
```fortran
module linked_list
  type :: link
    type(link), pointer :: next => null()
  end type link
end module
```

was leading to this generated code (just one s/r for brevity)
```fortran
subroutine f90wrap_link__get__next(this, f90wrap_next)
    use linked_list, only: link
    implicit none
    type link_ptr_type
        type(link), pointer :: p => NULL()
    end type link_ptr_type
    type link_ptr_type
        type(link), pointer :: p => NULL()
    end type link_ptr_type
    integer, intent(in)   :: this(2)
    type(link_ptr_type) :: this_ptr
    integer, intent(out) :: f90wrap_next(2)
    type(link_ptr_type) :: next_ptr

    this_ptr = transfer(this, this_ptr)
    next_ptr%p => this_ptr%p%next
    f90wrap_next = transfer(next_ptr,f90wrap_next)
end subroutine f90wrap_link__get__next
```
in which the the `type link_ptr_type` is defined twice.

The suggested fix works for this test problem and more complicated codes.

To reproduce (prior to fix):
```bash
cat << EOF > linked_list.f90
module linked_list
  type :: link
    type(link), pointer :: next => null()
  end type link
end module
EOF
f90wrap -m linked_list linked_list.f90
gfortran -c linked_list.f90 f90wrap_linked_list.f90
```