### PR TITLE
iso_c_binding support and numpy dtype bug fixed

### DIFF
--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -831,8 +831,8 @@ def fortran_array_type(typename, kind_map):
 
     # convert from C type names to numpy dtype strings
     c_type_to_numpy_type = {
-        'char' : 'string',
-        'signed_char' : 'string',
+        'char' : 'uint8',
+        'signed_char' : 'int8',
         'short' : 'int16',
         'int' : 'int32',
         'long_long' : 'int64',
@@ -842,7 +842,7 @@ def fortran_array_type(typename, kind_map):
         'complex_float' : 'complex64',
         'complex_double' : 'complex128',
         'complex_long_double' : 'complex256',
-        'string' : 'string',
+        'string' : 'str',
     }
 
     if c_type not in c_type_to_numpy_type:

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -589,7 +589,7 @@ def check_subt(cl, file, grab_hold_doc=True):
     global hold_doc
 
     out = Subroutine()
-
+        
     if re.match(subt, cl) != None:
 
         out.filename = file.filename
@@ -621,7 +621,7 @@ def check_subt(cl, file, grab_hold_doc=True):
         # get argument list
 
         if has_args:
-
+            cl = cl[:cl.find(')', 0)+1]
             cl = re.sub('\w+', '', cl, count=1)
             argl = re.split('[\W]+', cl)
 


### PR DESCRIPTION
A workground for the issue [#65 ](https://github.com/jameskermode/f90wrap/issues/65).

The Name argument in bind attribute is discarded right now. So extra works are needed to make it versatile.

This PR also fixed the bug about numpy dtype. 'string' is not a valid numpy dtype, it should be replaced by 'str'.