### PR TITLE
Bugfix and tests for comments interleaved in dummy argument lists

### DIFF
--- a/examples/subroutine_args/Makefile
+++ b/examples/subroutine_args/Makefile
@@ -1,0 +1,140 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = subroutine_mod
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = subroutine_mod
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = subroutine_mod
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
+
+
+clean:
+	-rm ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}.so \
+	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
+
+
+test: _${PYTHON_MODN}_pkg.so _${PYTHON_MODN}.so 
+	${PYTHON} tests.py
+

--- a/examples/subroutine_args/kind_map
+++ b/examples/subroutine_args/kind_map
@@ -1,0 +1,16 @@
+{
+ 'real':     {   '' : 'float',
+                '4' : 'float',
+              'isp' : 'float',
+                '8' : 'double',
+               'dp' : 'double',
+              'idp' : 'double'},
+ 'complex' : {   '' : 'complex_float',
+ 	            '8' : 'complex_double',
+ 	           '16' : 'complex_long_double',
+ 	           'dp' : 'complex_double'},
+ 'integer' : {  '4' : 'int',
+	            '8' : 'long_long',
+	           'dp' : 'long_long' }
+}
+

--- a/examples/subroutine_args/subroutine_mod.f90
+++ b/examples/subroutine_args/subroutine_mod.f90
@@ -23,17 +23,17 @@ contains
 
     end subroutine routine_with_multiline_args
 
-    ! subroutine routine_with_commented_args(&
-    !      ! Some arbitrary comment...
-    !      & a, b, &
-    !      ! ... to highlight Fortran line continuation.
-    !      & c, d)
-    !   integer, intent(in) :: a, b
-    !   integer, intent(out) :: c, d
+    subroutine routine_with_commented_args(&
+         ! Some arbitrary comment...
+         & a, b, &
+         ! ... to highlight Fortran line continuation.
+         & c, d)
+      integer, intent(in) :: a, b
+      integer, intent(out) :: c, d
 
-    !   c = a + b
-    !   d = a * b
+      c = a + b
+      d = a * b
 
-    ! end subroutine routine_with_commented_args
+    end subroutine routine_with_commented_args
 
 end module subroutine_mod

--- a/examples/subroutine_args/subroutine_mod.f90
+++ b/examples/subroutine_args/subroutine_mod.f90
@@ -36,4 +36,18 @@ contains
 
     end subroutine routine_with_commented_args
 
+    subroutine routine_with_more_commented_args(&
+       ! Some additional commenting...
+         & a, b, &
+       ! ... to highlight the true ...
+       ! ... beauty of the FORTRAN language.
+         & c, d)
+      integer, intent(in) :: a, b
+      integer, intent(out) :: c, d
+
+      c = a + b
+      d = a * b
+
+    end subroutine routine_with_more_commented_args
+
 end module subroutine_mod

--- a/examples/subroutine_args/subroutine_mod.f90
+++ b/examples/subroutine_args/subroutine_mod.f90
@@ -1,0 +1,39 @@
+module subroutine_mod
+
+    implicit none
+
+contains
+
+    subroutine routine_with_simple_args(a, b, c, d)
+      integer, intent(in) :: a, b
+      integer, intent(out) :: c, d
+
+      c = a + b
+      d = a * b
+
+    end subroutine routine_with_simple_args
+
+    subroutine routine_with_multiline_args(&
+         & a, b, c, d)
+      integer, intent(in) :: a, b
+      integer, intent(out) :: c, d
+
+      c = a + b
+      d = a * b
+
+    end subroutine routine_with_multiline_args
+
+    ! subroutine routine_with_commented_args(&
+    !      ! Some arbitrary comment...
+    !      & a, b, &
+    !      ! ... to highlight Fortran line continuation.
+    !      & c, d)
+    !   integer, intent(in) :: a, b
+    !   integer, intent(out) :: c, d
+
+    !   c = a + b
+    !   d = a * b
+
+    ! end subroutine routine_with_commented_args
+
+end module subroutine_mod

--- a/examples/subroutine_args/tests.py
+++ b/examples/subroutine_args/tests.py
@@ -11,3 +11,6 @@ assert c == 5 and d == 6
 
 c, d = mod.routine_with_commented_args(2, 3)
 assert c == 5 and d == 6
+
+c, d = mod.routine_with_more_commented_args(2, 3)
+assert c == 5 and d == 6

--- a/examples/subroutine_args/tests.py
+++ b/examples/subroutine_args/tests.py
@@ -1,0 +1,13 @@
+
+import subroutine_mod
+
+mod = subroutine_mod.Subroutine_Mod
+
+c, d = mod.routine_with_simple_args(2, 3)
+assert c == 5 and d == 6
+
+c, d = mod.routine_with_multiline_args(2, 3)
+assert c == 5 and d == 6
+
+c, d = mod.routine_with_commented_args(2, 3)
+assert c == 5 and d == 6

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -238,16 +238,18 @@ class F90File(object):
                 comm_index = cline.find('!')
                 while (cont_index != -1 and (comm_index == -1 or comm_index > cont_index)) or \
                         (cont2_index != -1):
-                    if cont_index != -1:
-                        cont = cline[:cont_index].strip()
-                    else:
-                        cont = cline.strip()
                     cont2 = self.lines[1].strip()
                     if cont2.startswith('&'):
                         cont2 = cont2[1:].strip()
-                    # Skip interleaved comments
+
+                    # Skip interleaved comments starting with `!`
+                    if cont_index != -1 and not cont2.startswith('!'):
+                        cont = cline[:cont_index].strip()
+                    else:
+                        cont = cline.strip()
                     if not cont2.startswith('!'):
                         cont = cont + cont2
+
                     self.lines = [cont] + self.lines[2:]
                     self._lineno = self._lineno + 1
                     cline = self.lines[0].strip()

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -245,7 +245,9 @@ class F90File(object):
                     cont2 = self.lines[1].strip()
                     if cont2.startswith('&'):
                         cont2 = cont2[1:].strip()
-                    cont = cont + cont2
+                    # Skip interleaved comments
+                    if not cont2.startswith('!'):
+                        cont = cont + cont2
                     self.lines = [cont] + self.lines[2:]
                     self._lineno = self._lineno + 1
                     cline = self.lines[0].strip()


### PR DESCRIPTION
Fortran's line continuation can be interleaved with comments, often used in legacy applications to annotate groupings of dummy arguments. While the `f90wrap.parser` generally seems to handle comments between continued lines, subtle bugs can cause erroneous dummy argument lists. This PR fixes these subtle bugs and adds tests with multi-line dummy argument lists interrupted by comments.

Note: I've tried to emulate existing test setups, but please let me know if there are particular style changes required to bring the new tests in line with the existing codebase. 