### PR TITLE
Array pointers in derived types

### DIFF
--- a/examples/derivedtypes/library.f90
+++ b/examples/derivedtypes/library.f90
@@ -90,11 +90,9 @@ contains
         use datatypes, only: pointer_arrays
         INTEGER, INTENT(in) :: m, n
         TYPE(pointer_arrays), INTENT(out) :: dertype
-        REAL(idp), DIMENSION(:,:), ALLOCATABLE, TARGET :: chi
         INTEGER :: i, j
 
-        ALLOCATE(chi(m,n))
-        dertype%chi => chi
+        ALLOCATE(dertype%chi(m,n))
         dertype%chi(:,:) = 100.0_idp
         dertype%chi(m-2,n-1) = -10.0_idp
     end subroutine return_dertype_pointer_arrays

--- a/examples/derivedtypes/library.f90
+++ b/examples/derivedtypes/library.f90
@@ -97,15 +97,15 @@ contains
         dertype%chi(m-2,n-1) = -10.0_idp
     end subroutine return_dertype_pointer_arrays
 
-!    subroutine modify_dertype_pointer_arrays(dertype)
-!        use datatypes, only: pointer_arrays
-!        TYPE(pointer_arrays), INTENT(inout) :: dertype
-!        INTEGER :: i, j, m, n
-!        m = dertype%chi_shape(1)
-!        n = dertype%chi_shape(2)
-!        dertype%chi(:,:) = dertype%chi(:,:)*dertype%chi(:,:)
-!        dertype%chi(m-2, n-1) = -9.0_idp
-!    end subroutine modify_dertype_pointer_arrays
+   subroutine modify_dertype_pointer_arrays(dertype)
+       use datatypes, only: pointer_arrays
+       TYPE(pointer_arrays), INTENT(inout) :: dertype
+       INTEGER :: i, j, m, n
+       m = dertype%chi_shape(1)
+       n = dertype%chi_shape(2)
+       dertype%chi(:,:) = dertype%chi(:,:)*dertype%chi(:,:)
+       dertype%chi(m-2, n-1) = -9.0_idp
+   end subroutine modify_dertype_pointer_arrays
 
    subroutine return_dertype_alloc_arrays(m, n, dertype)
         use datatypes_allocatable, only: alloc_arrays

--- a/examples/derivedtypes/tests.py
+++ b/examples/derivedtypes/tests.py
@@ -170,19 +170,13 @@ class BaseTests(object):
         self.assert_(isinstance(ndt.mu.delta, float))
         self.assert_(isinstance(ndt.nu, self.lib.datatypes.fixed_shape_arrays))
 
-    # this test will fail because pointer/alloc arrays as arguments are not
-    # supported.
-    # expectedFailure only added to unittest module in Python 2.7
-    # @unittest.expectedFailure
-    # def test_return_dertype_pointer_arrays(self):
-    #     m, n = 9, 5
-    #     dt = self.lib.library.return_dertype_pointer_arrays(m, n)
-    #     self.assert_(isinstance(dt, self.lib.datatypes.Pointer_Arrays))
-    #     expected = np.ones((m, n), order='F', dtype=np.float64) * 100.0
-    #     expected[m-3, n-2] = -10.0
-    #     # it seems dt.chi can not be accessed from Python
-    #     # expected failure
-    #     np.testing.assert_allclose(dt.chi, expected)
+    def test_return_dertype_pointer_arrays(self):
+        m, n = 9, 5
+        dt = self.lib.library.return_dertype_pointer_arrays(m, n)
+        self.assert_(isinstance(dt, self.lib.datatypes.pointer_arrays))
+        expected = np.ones((m, n), order='F', dtype=np.float64) * 100.0
+        expected[m-3, n-2] = -10.0
+        np.testing.assert_allclose(dt.chi, expected)
 
     def test_return_dertype_alloc_arrays(self):
         m, n = 9, 5

--- a/examples/derivedtypes/tests.py
+++ b/examples/derivedtypes/tests.py
@@ -187,19 +187,31 @@ class BaseTests(object):
         expected[m-3, n-2] = -1.0
         np.testing.assert_allclose(dt.chi, expected)
 
-#    def test_modify_dertype_pointer_arrays(self):
-#
-#        # create an array
-#        dt = self.lib.datatypes.Pointer_Arrays()
-#        m, n = 9, 5
-#        dt.chi = np.mgrid[0:m,0:n][0]
-#        dt.chi_shape = np.array([m,n], dtype=np.int32)
-#        self.lib.library.modify_dertype_pointer_arrays(dt)
-#
-#        expected = np.ones((m, n), order='F', dtype=np.float64) * 81.0
-#        expected[0, 0] = 2500.0
-#        expected[m-3, n-2] = -9.0
-#        np.testing.assert_allclose(dt.chi, expected)
+    def test_modify_dertype_pointer_arrays(self):
+        # the array can only be created from Fortran and this will fail
+        # dt = self.lib.datatypes.Pointer_Arrays()
+        # m, n = 9, 5
+        # dt.chi = np.mgrid[0:m,0:n][0]
+        # dt.chi_shape = np.array([m,n], dtype=np.int32)
+
+        # create an array in Fortran
+        m, n = 9, 5
+        dt = self.lib.library.return_dertype_pointer_arrays(m, n)
+        # the shape of the 2D array is also part of the derived type
+        # so we do not have to pass the shape of the array again when modifying
+        # the those arrays in other subroutines
+        dt.chi_shape = np.array([m, n], dtype=np.int32)
+        # we can also place a new array in here as long as we keep the same
+        # data type
+        dt.chi = np.ndarray((m,n), dtype=np.float64)
+        dt.chi[:,:] = 9.0
+        dt.chi[0,0] = 50.0
+        self.lib.library.modify_dertype_pointer_arrays(dt)
+
+        expected = np.ones((m, n), order='F', dtype=np.float64) * 81.0
+        expected[0, 0] = 2500.0
+        expected[m-3, n-2] = -9.0
+        np.testing.assert_allclose(dt.chi, expected)
 
     def test_modify_dertype_alloc_arrays(self):
 

--- a/f90wrap/transform.py
+++ b/f90wrap/transform.py
@@ -314,11 +314,6 @@ class UnwrappablesRemover(ft.FortranTransformer):
                 # Get the number of dimensions of the element (if any)
                 dims = [attr for attr in element.attributes if attr.startswith(
                     'dimension')]  # dims = filter(lambda x: x.startswith('dimension'), element.attributes) provides a filter object, so dims == [] would ALWAYS be false
-                # Skip this if the type is not do-able
-                if 'pointer' in element.attributes and dims != []:
-                    warnings.warn('removing %s.%s due to pointer attribute' %
-                                  (node.name, element.name))
-                    continue
                 if element.type.lower() == 'type(c_ptr)':
                     warnings.warn('removing %s.%s as type(c_ptr) unsupported' %
                                   (node.name, element.name))


### PR DESCRIPTION
This PR enables the creation and modification of derived types that contain array pointers and fixes the according tests (they exist, but had been disabled). The creation test was bugged in itself, since it associated the pointer with an array local to the subroutine, which becomes undefined (and possibly unallocated) once the program leaves that subroutine scope, as explained [here](https://stackoverflow.com/questions/11837616/fortran-allocatable-array-lifetime).

In general, array pointers like`real, pointer :: var` in derived types seem to work just like allocatable arrays (eg. `real, allocatable :: var` (can be passed around opaquely, but need to be allocated by custom Forrtan code). This means the restriction to skip them in `transform.py` can be lifted.