### PR TITLE
Fix and test aliasing across modules (namespacing)

### DIFF
--- a/examples/derived-type-aliases/Makefile
+++ b/examples/derived-type-aliases/Makefile
@@ -1,0 +1,141 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = derived_types_mod
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = mytype_mod othertype_mod
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = mytype_mod othertype_mod
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _mytype.so _othertype.so test
+
+
+clean:
+	-rm  *.o *.a *.so *.mod *.fpp f90wrap*.f90 f90wrap*.o 
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libmytype_mod.a: mytype_mod.o
+	${LIBTOOL} $@ $?
+
+libothertype_mod.a: othertype_mod.o
+	${LIBTOOL} $@ $?
+
+
+_mytype.so: libmytype_mod.a mytype_mod.f90
+	f90wrap -m mytype mytype_mod.f90 -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _mytype -L. -lmytype_mod f90wrap_mytype_mod.f90
+
+_othertype.so: libothertype_mod.a othertype_mod.f90
+	f90wrap -m othertype othertype_mod.f90 -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _othertype -L. -lothertype_mod f90wrap_othertype_mod.f90
+
+
+test: _mytype.so _othertype.so
+	${PYTHON} tests.py
+

--- a/examples/derived-type-aliases/kind_map
+++ b/examples/derived-type-aliases/kind_map
@@ -1,0 +1,16 @@
+{
+ 'real':     {   '' : 'float',
+                '4' : 'float',
+              'isp' : 'float',
+                '8' : 'double',
+               'dp' : 'double',
+              'idp' : 'double'},
+ 'complex' : {   '' : 'complex_float',
+ 	            '8' : 'complex_double',
+ 	           '16' : 'complex_long_double',
+ 	           'dp' : 'complex_double'},
+ 'integer' : {  '4' : 'int',
+	            '8' : 'long_long',
+	           'dp' : 'long_long' }
+}
+

--- a/examples/derived-type-aliases/mytype_mod.f90
+++ b/examples/derived-type-aliases/mytype_mod.f90
@@ -1,0 +1,25 @@
+module mytype_mod
+
+  implicit none
+
+  type mytype
+     integer :: a
+  end type mytype
+
+contains
+
+  function constructor() result(obj)
+    type(mytype) :: obj
+
+    obj%a = 2
+  end function constructor
+
+  subroutine plus_b(obj, b, c)
+    type(mytype) :: obj
+    integer, intent(in) :: b
+    integer, intent(out) :: c
+
+    c = obj%a + b
+  end subroutine plus_b
+
+end module mytype_mod

--- a/examples/derived-type-aliases/othertype_mod.f90
+++ b/examples/derived-type-aliases/othertype_mod.f90
@@ -1,0 +1,25 @@
+module othertype_mod
+
+  implicit none
+
+  type othertype
+     integer :: a
+  end type othertype
+
+contains
+
+  function constructor() result(obj)
+    type(othertype) :: obj
+
+    obj%a = 5
+  end function constructor
+
+  subroutine plus_b(obj, b, c)
+    type(othertype) :: obj
+    integer, intent(in) :: b
+    integer, intent(out) :: c
+
+    c = obj%a + b
+  end subroutine plus_b
+
+end module othertype_mod

--- a/examples/derived-type-aliases/tests.py
+++ b/examples/derived-type-aliases/tests.py
@@ -1,0 +1,13 @@
+from mytype import mytype_mod
+
+mine = mytype_mod.constructor()
+assert mine.a == 2
+c = mytype_mod.plus_b(mine, b=3)
+assert c == 5
+
+from othertype import othertype_mod
+
+other = othertype_mod.constructor()
+assert other.a == 5
+d = othertype_mod.plus_b(other, b=4)
+assert d == 9

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -377,6 +377,7 @@ except ValueError:
                 for ret_val in node.ret_val:
                     if ret_val.type.startswith('type'):
                         cls_name = normalise_class_name(ft.strip_type(ret_val.type), self.class_names)
+                        cls_name = self.py_mod_name + '.' + cls_name
                         cls_name = 'f90wrap.runtime.lookup_class("%s")' % cls_name
                         cls_mod_name = self.types[ft.strip_type(ret_val.type)].mod_name
                         cls_mod_name = self.py_mod_names.get(cls_mod_name, cls_mod_name)
@@ -442,7 +443,7 @@ except ValueError:
         logging.info('PythonWrapperGenerator visiting type %s' % node.name)
         node.dt_array_initialisers = []
         cls_name = normalise_class_name(node.name, self.class_names)
-        self.write('@f90wrap.runtime.register_class("%s")' % cls_name)
+        self.write('@f90wrap.runtime.register_class("%s.%s")' % (self.py_mod_name, cls_name))
         self.write('class %s(f90wrap.runtime.FortranDerivedType):' % cls_name)
         self.indent()
         self.write(format_doc_string(node))


### PR DESCRIPTION
Apologies if this one is a little odd, but my use case for this is rather important: If multiple invocations of `f90wrap` are used within an automated testing cycle (from within the same interpreter instance), derived type and subroutine name clashes can cause the runtime registry to fail. The necessary namespacing to get around this can be provided through different module names, but these have thus far been ignored by the runtime. This PR fixes this through implicit namespacing in the use of the runtime class registry and adds a test that compiles two separate modules with aliasing type and subroutine names, but differing values.