### PR TITLE
Datatypes must be uppercase in Python

### DIFF
--- a/examples/arrays_in_derived_types_issue50/tests.py
+++ b/examples/arrays_in_derived_types_issue50/tests.py
@@ -17,15 +17,15 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 from issue50 import module_test as tp
 from numpy import zeros, ones, float32, abs, max
 
-a = tp.real_array()
+a = tp.Real_Array()
 print("This is the freshly allocated array : " + str(a.item))
-a.item = ones(6, dtype=float32) 
+a.item = ones(6, dtype=float32)
 print("This is sent to fortran : " + str(a.item))
 tp.testf(a)
 print("This is received by python : " + str(a.item))

--- a/examples/cylinder/tests.py
+++ b/examples/cylinder/tests.py
@@ -17,7 +17,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 
@@ -36,8 +36,8 @@ class TestExample(unittest.TestCase):
         pass
 
     def test_auto_diff(self):
-        d1 = Example.Dual_Num_Auto_Diff.DUAL_NUM()
-        d2 = Example.Dual_Num_Auto_Diff.DUAL_NUM()
+        d1 = Example.Dual_Num_Auto_Diff.Dual_Num()
+        d2 = Example.Dual_Num_Auto_Diff.Dual_Num()
         d3 = Example.Mcyldnad.cyldnad(d1, d2)
 
 if __name__ == '__main__':

--- a/examples/derivedtypes/tests.py
+++ b/examples/derivedtypes/tests.py
@@ -17,7 +17,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 # -*- coding: utf-8 -*-
@@ -58,7 +58,7 @@ class BaseTests(object):
 
     def test_return_a_dt_func(self):
         dt = self.lib.library.return_a_dt_func()
-        self.assert_(isinstance(dt, self.lib.datatypes.different_types))
+        self.assert_(isinstance(dt, self.lib.datatypes.Different_Types))
         self.assertEqual(dt.alpha, 1) # logicals, so 1/0 instead of T/F
         self.assertEqual(dt.beta, 666)
         self.assertEqual(dt.delta, 666.666)
@@ -103,19 +103,19 @@ class BaseTests(object):
 
         dt = self.lib.library.set_derived_type(dt_beta=dt_beta,
                                                dt_delta=dt_delta)
-        self.assert_(isinstance(dt, self.lib.datatypes.different_types))
+        self.assert_(isinstance(dt, self.lib.datatypes.Different_Types))
         self.assertEqual(dt.beta, dt_beta)
         self.assertEqual(dt.delta, dt_delta)
 
     def test_modify_derived_types(self):
 
-        dt1 = self.lib.datatypes.different_types()
+        dt1 = self.lib.datatypes.Different_Types()
         dt1.beta = 10
         dt1.delta = 11.11
-        dt2 = self.lib.datatypes.different_types()
+        dt2 = self.lib.datatypes.Different_Types()
         dt2.beta = 20
         dt2.delta = 22.22
-        dt3 = self.lib.datatypes.different_types()
+        dt3 = self.lib.datatypes.Different_Types()
         dt3.beta = 30
         dt3.delta = 33.33
 
@@ -133,7 +133,7 @@ class BaseTests(object):
     def test_modify_dertype_multiple_arrays(self):
 
         dt = self.lib.library.modify_dertype_fixed_shape_arrays()
-        self.assert_(isinstance(dt, self.lib.datatypes.fixed_shape_arrays))
+        self.assertTrue(isinstance(dt, self.lib.datatypes.Fixed_Shape_Arrays))
 
         self.assertEqual(dt.eta.dtype, np.int32)
         eta = np.ones((10,4), dtype=np.int)
@@ -164,16 +164,16 @@ class BaseTests(object):
     #     np.testing.assert_array_equal(dt.theta, theta*np.float32(2.0))
 
     def test_nested_dertype(self):
-        ndt = self.lib.datatypes.nested()
-        self.assert_(isinstance(ndt.mu.alpha, int)) # boolean/logical in F though)
-        self.assert_(isinstance(ndt.mu.beta, int))
-        self.assert_(isinstance(ndt.mu.delta, float))
-        self.assert_(isinstance(ndt.nu, self.lib.datatypes.fixed_shape_arrays))
+        ndt = self.lib.datatypes.Nested()
+        self.assertTrue(isinstance(ndt.mu.alpha, int)) # boolean/logical in F though)
+        self.assertTrue(isinstance(ndt.mu.beta, int))
+        self.assertTrue(isinstance(ndt.mu.delta, float))
+        self.assertTrue(isinstance(ndt.nu, self.lib.datatypes.Fixed_Shape_Arrays))
 
     def test_return_dertype_pointer_arrays(self):
         m, n = 9, 5
         dt = self.lib.library.return_dertype_pointer_arrays(m, n)
-        self.assert_(isinstance(dt, self.lib.datatypes.pointer_arrays))
+        self.assertTrue(isinstance(dt, self.lib.datatypes.Pointer_Arrays))
         expected = np.ones((m, n), order='F', dtype=np.float64) * 100.0
         expected[m-3, n-2] = -10.0
         np.testing.assert_allclose(dt.chi, expected)
@@ -182,7 +182,7 @@ class BaseTests(object):
         m, n = 9, 5
         dt = self.lib.library.return_dertype_alloc_arrays(m, n)
         dt.chi_shape = np.array([m, n], dtype=np.int32)
-        self.assert_(isinstance(dt, self.lib.datatypes_allocatable.alloc_arrays))
+        self.assert_(isinstance(dt, self.lib.datatypes_allocatable.Alloc_Arrays))
         expected = np.ones((m, n), order='F', dtype=np.float64) * 10.0
         expected[m-3, n-2] = -1.0
         np.testing.assert_allclose(dt.chi, expected)
@@ -244,7 +244,7 @@ class BaseTests(object):
 
     def test_alloc_arrays(self):
         m, n = 10, 4
-        dt = self.lib.datatypes_allocatable.alloc_arrays()
+        dt = self.lib.datatypes_allocatable.Alloc_Arrays()
         self.lib.datatypes_allocatable.init_alloc_arrays(dt, m, n)
         self.assertEqual(dt.chi.shape, (m,n))
 
@@ -256,7 +256,7 @@ class BaseTests(object):
 
     def test_nested_alloc_arrays(self):
         n = 10
-        dt = self.lib.datatypes.array_nested()
+        dt = self.lib.datatypes.Array_Nested()
         self.lib.datatypes.init_array_nested(dt, n)
 
         self.assertEqual(len(dt.xi), n)

--- a/examples/example2/test_module.py
+++ b/examples/example2/test_module.py
@@ -17,13 +17,13 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 from __future__ import print_function
 
 #=======================================================================
-#           simple test for f90wrap 
+#           simple test for f90wrap
 #=======================================================================
 
 
@@ -36,15 +36,15 @@ import numpy as np
 from mockdt import *
 
 #=======================================================================
-# call a "top-level" subroutine. This refers to subroutines that are 
+# call a "top-level" subroutine. This refers to subroutines that are
 # present outside of modules, and do not operate on derived types AFAIK
 #=======================================================================
 
-#This particular routine sets some numeric constants 
+#This particular routine sets some numeric constants
 assign_constants()
 
 #=======================================================================
-#Check if the subroutine worked : it modifies the "precision" module 
+#Check if the subroutine worked : it modifies the "precision" module
 #variables
 #=======================================================================
 
@@ -65,7 +65,7 @@ print(precision.one,precision.two, precision.three,precision.four)
 #           Declare the SolverOptions derived type
 #=======================================================================
 
-Options =  Defineallproperties.SolverOptionsDef()
+Options =  Defineallproperties.Solveroptionsdef()
 
 print(type(Options.airframevib))
 Options.airframevib = 0

--- a/examples/mockderivetype/test.py
+++ b/examples/mockderivetype/test.py
@@ -17,7 +17,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 import numpy as np
@@ -27,7 +27,7 @@ from mockdt import (define_a_type,
                     use_a_type,
                     top_level)
 
-a = define_a_type.atype() # calls initialise()
+a = define_a_type.Atype() # calls initialise()
 
 a.rl = 3.0 # calls set()
 assert(a.rl == 3.0)
@@ -39,7 +39,7 @@ assert(np.all(a.vec == 1.0))
 
 a.dtype.rl = 1.0 # calls set()
 
-my_l2 = leveltwomod.leveltwo(4.0) # calls initialise()
+my_l2 = leveltwomod.Leveltwo(4.0) # calls initialise()
 a.dtype = my_l2 # calls set()
 assert(a.dtype.rl == my_l2.rl)
 
@@ -77,7 +77,7 @@ for i in range(len(use_a_type.p_array)):
 a = define_a_type.return_a_type_func()
 assert(a.bool == 1 or a.bool == -1) # ifort uses -1 for logical true
 assert(a.integ == 42)
-    
+
 # test subroutine with intent(out) derived type argument
 a = define_a_type.return_a_type_sub()
 assert(a.bool == 1 or a.bool == -1) # ifort uses -1 for logical true

--- a/examples/mod_arg_clash/test.py
+++ b/examples/mod_arg_clash/test.py
@@ -17,12 +17,12 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 from __future__ import print_function
 import test.cell
 
-c = test.cell.unit_cell()
+c = test.cell.Unit_Cell()
 test.cell.cell_dosomething(c, 1, 'Si')
 print(c)

--- a/examples/passbyreference/example_mymodule.py
+++ b/examples/passbyreference/example_mymodule.py
@@ -17,14 +17,14 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 from __future__ import print_function
 import mymodule
 import numpy as np
 
-tt = mymodule.Mymodule.mytype()
+tt = mymodule.Mymodule.Mytype()
 tt.val = 17
 b=np.array(17)
 

--- a/examples/type_bn/test.py
+++ b/examples/type_bn/test.py
@@ -17,11 +17,11 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 import type_bn
 
-a = type_bn.module_structure.type_face()
+a = type_bn.module_structure.Type_Face()
 a.type = 1
 assert(a.type == 1)


### PR DESCRIPTION
Many of the tests in `examples` fail due not found attributes. Change the names of the data to `Upper_Case` fixes this problem. I worked with version  0.1.4 installed via pip.