### PR TITLE
Small fix of `class_names` mapping

### DIFF
--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -288,7 +288,7 @@ except ValueError:
             self.dedent()  # finish the FortranModule class
             self.write()
             # instantise the module class
-            self.write('%s = %s()' % (node.name, node.name.title()))
+            self.write('%s = %s()' % (node.name, cls_name))
             self.write()
 
         self.current_module = None
@@ -453,7 +453,7 @@ except ValueError:
         for proc in node.procedures:
             proc_name = ''
             if not self.make_package:
-                proc_name += proc.mod_name.title() + '.'
+                proc_name += normalise_class_name(proc.mod_name, self.class_names) + '.'
             elif cls_name is not None:
                 proc_name += cls_name + '.'
             if hasattr(proc, 'method_name'):

--- a/scripts/f90wrap
+++ b/scripts/f90wrap
@@ -280,7 +280,8 @@ USAGE
         print()
 
         for type_name, typ in types.items():
-            class_names[type_name] = typ.orig_name
+            if not type_name in class_names.keys():
+                class_names[type_name] = typ.orig_name
         print('Class name mapping:')
         pprint.pprint(class_names)
 


### PR DESCRIPTION
The issue was that when `class_names` was used, mapping of module and class names in the Python wrapper script was not consistent: some names remained by default.
Also, derived type name mapping was not functioning at all. Hence an additional `if`-line in the `f90wrap` script.