### PR TITLE
 Add example setting up a python callback function 

### DIFF
--- a/examples/callback_print_function_issue93/Makefile
+++ b/examples/callback_print_function_issue93/Makefile
@@ -1,0 +1,144 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = CBF
+# mapping between Fortran and C types
+# Note that in this case this may be superfluous, and at any rate
+# 'character' : {'': 'char'}
+# was removed from the kind_map as this was leading to:
+# f90wrap: RuntimeError('Unknown combination of type "character" and kind "1024" - add to kind map and try again')
+# I could not locate useful documentation for what to do.
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = cback caller
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = cback caller
+# LIBSRC_WRAP_SOURCES = caller
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
+
+
+clean:
+	-rm ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}*.so \
+	*.mod *.fpp f90wrap*.f90 f90wrap*.o *.o
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v  --callback pyfunc_print
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90 ${LIBSRC_WRAP_FILES}
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P --callback pyfunc_print
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90 ${LIBSRC_WRAP_FILES}
+
+test: _${PYTHON_MODN}_pkg.so _${PYTHON_MODN}.so
+	${PYTHON} tests.py

--- a/examples/callback_print_function_issue93/README.md
+++ b/examples/callback_print_function_issue93/README.md
@@ -1,0 +1,38 @@
+python function callback
+==============
+
+This example illustrate how to set up an external callback so that a python function can be called, namely to capture messages for display in a Jupyter notebook (or passed to a log, etc.).
+
+As of 2019-11 there is nothing specific to f90wrap in the content of this folder (f2py should handle it to). Finding how to set up a callback function registration was a day-long pain for yours truly. This example is written in the hope this will ease the pain for others.
+
+## Related resources
+
+
+* [Call-back arguments in f2py](https://numpy.org/devdocs/f2py/python-usage.html#call-back-arguments)
+* Callback registration to e.g. trap C++ exceptions and report through R, Python, etc. [here](https://github.com/csiro-hydroinformatics/moirai/blob/master/src/reference_handle_map_export.cpp)
+
+
+## Build
+
+This example has been tested with ```gfortran```  on Linux 64bit.
+
+To build and wrap with f90wrap, use the included ```Makefile```:
+
+```sh
+make
+```
+
+and before rebuilding, clean-up with:
+
+```sh
+make clean
+```
+
+A simple unittest is included in ```tests.py```.
+
+Author
+------
+
+Jean-Michel Perraud: <per202@csiro.au>
+
+

--- a/examples/callback_print_function_issue93/callback_print_output_python.ipynb
+++ b/examples/callback_print_function_issue93/callback_print_output_python.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting a callback message to trap print output\n",
+    "\n",
+    "`print *` statements in Fortran do print to the Python console stdandard output, but there is no satisfactory way to do the same with Jupyter notebooks (so far as I know). \n",
+    "\n",
+    "This document illustrates how to do so once you've built generated the module with `make`, purposely illustrating a workaround apparently needed to get the callback working. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import CBF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A function `test_write_msg` should trigger a call back to a python function; as we have not registered the callback the following call **as expected fails**:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "error",
+     "evalue": "cb: Callback pyfunc_print not defined (as an argument or module _CBF attribute).\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31merror\u001b[0m                                     Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-250d0d572965>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mCBF\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcaller\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtest_write_msg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/src/github/f90wrap/examples/callback_print_function_issue93/CBF.py\u001b[0m in \u001b[0;36mtest_write_msg\u001b[0;34m()\u001b[0m\n\u001b[1;32m     50\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m         \"\"\"\n\u001b[0;32m---> 52\u001b[0;31m         \u001b[0m_CBF\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mf90wrap_test_write_msg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     54\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mstaticmethod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31merror\u001b[0m: cb: Callback pyfunc_print not defined (as an argument or module _CBF attribute).\n"
+     ]
+    }
+   ],
+   "source": [
+    "CBF.caller.test_write_msg()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to register the callback as follows. Admitedly low-level, to illustrate the mechanism."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(msg): \n",
+    "    print(\"Yo! \" + msg)\n",
+    "CBF._CBF.pyfunc_print = f\n",
+    "\n",
+    "# We need to prime the callback with a call \"under the hood\", not sure why."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following call should then work, but for unknown reasons does not without another prepping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "f() missing 1 required positional argument: 'msg'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-250d0d572965>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mCBF\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcaller\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtest_write_msg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/src/github/f90wrap/examples/callback_print_function_issue93/CBF.py\u001b[0m in \u001b[0;36mtest_write_msg\u001b[0;34m()\u001b[0m\n\u001b[1;32m     50\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m         \"\"\"\n\u001b[0;32m---> 52\u001b[0;31m         \u001b[0m_CBF\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mf90wrap_test_write_msg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     54\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mstaticmethod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: f() missing 1 required positional argument: 'msg'"
+     ]
+    }
+   ],
+   "source": [
+    "CBF.caller.test_write_msg()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For unknown reasons, I found that I needed to trigger the call to the function `write_message` normally not meant to be called directly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "write_message(msg)\n",
+      "\n",
+      "Wrapper for ``write_message``.\n",
+      "\n",
+      "Parameters\n",
+      "----------\n",
+      "msg : input string(len=-1)\n",
+      "\n",
+      "Notes\n",
+      "-----\n",
+      "Call-back functions::\n",
+      "\n",
+      "  def pyfunc_print(msg): return \n",
+      "  Required arguments:\n",
+      "    msg : input string(len=-1)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(CBF._CBF.cback.write_message.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yo! blah\n"
+     ]
+    }
+   ],
+   "source": [
+    "CBF._CBF.cback.write_message('blah')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Subsequently other calls to higher level functions then work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yo! from test_write_msg\n"
+     ]
+    }
+   ],
+   "source": [
+    "CBF.caller.test_write_msg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yo! from test_write_msg\n"
+     ]
+    }
+   ],
+   "source": [
+    "CBF.caller.test_write_msg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yo! from test_write_msg_2\n"
+     ]
+    }
+   ],
+   "source": [
+    "CBF.caller.test_write_msg_2()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yo! from test_write_msg\n"
+     ]
+    }
+   ],
+   "source": [
+    "CBF.caller.test_write_msg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Py3 (DCX)",
+   "language": "python",
+   "name": "dcx"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/callback_print_function_issue93/caller.f90
+++ b/examples/callback_print_function_issue93/caller.f90
@@ -1,0 +1,28 @@
+
+module caller
+    use cback
+    implicit none
+    
+    public
+
+contains
+
+subroutine test_write_msg()
+    call write_message("from test_write_msg")
+    return
+end
+
+subroutine test_write_msg_2()
+    call write_message("from test_write_msg_2")
+    return
+end
+
+! character(len=20) function test_return_msg()
+!     test_return_msg = return_message("from test_return_msg")
+! end
+
+! character(len=20) function test_return_msg_2()
+!     test_return_msg_2 = return_message("from test_return_msg_2")
+! end
+
+end module

--- a/examples/callback_print_function_issue93/cback.f90
+++ b/examples/callback_print_function_issue93/cback.f90
@@ -1,0 +1,30 @@
+
+module cback
+    implicit none
+    
+    public
+
+    contains
+    
+    subroutine write_message(msg)
+        !f2py    intent(callback, hide) pyfunc_print
+        external pyfunc_print
+        character(len= *) :: msg
+        call pyfunc_print(msg)
+    end
+
+    ! TODO cannot seem to make it work. Leads to "error: ‘PyStringObject’ undeclared"
+    ! character(len=20) function return_message(msg)
+    !     !f2py    intent(callback, hide) pyfunc_return
+    !     external pyfunc_return
+    !     character(len=20) pyfunc_return
+    !     !f2py character(len=20) y,x
+    !     !f2py y = py_func(x)
+    !     character(len= *) :: msg
+    !     character(len=20) :: returned_msg
+    !     write(returned_msg,*)msg
+    !     returned_msg = pyfunc_return(msg)
+    !     return_message = returned_msg(1:20)
+    ! end
+
+end module

--- a/examples/callback_print_function_issue93/kind_map
+++ b/examples/callback_print_function_issue93/kind_map
@@ -1,0 +1,9 @@
+{
+ 'real':     {'': 'float',
+              '8': 'double',
+              'dp': 'double',
+              'idp':'double'},
+ 'integer' : {'4': 'int',
+	          '8': 'long_long',
+			  'dp': 'long_long' }
+}

--- a/examples/callback_print_function_issue93/tests.py
+++ b/examples/callback_print_function_issue93/tests.py
@@ -1,0 +1,61 @@
+#  f90wrap: F90 to Python interface generator with derived type support
+#
+#  Copyright James Kermode 2011-2018
+#
+#  This file is part of f90wrap
+#  For the latest version see github.com/jameskermode/f90wrap
+#
+#  f90wrap is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  f90wrap is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
+#
+#  If you would like to license the source code under different terms,
+#  please contact James Kermode, james.kermode@gmail.com
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jan 25 2018
+
+@author: Gaetan Kenway
+"""
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import CBF
+
+class TestExample(unittest.TestCase):
+
+    def setUp(self):
+
+        pass
+
+    def test_basic(self):
+        print(CBF._CBF.cback.write_message.__doc__)
+        def f(msg): 
+            print("Yo! " + msg)
+        CBF._CBF.pyfunc_print = f
+        # We need to prime the callback with a call "under the hood", not sure why.
+        CBF._CBF.cback.write_message('blah')
+        # Subsequently other calls to higher level functions work.
+        CBF.caller.test_write_msg()
+        CBF.caller.test_write_msg()
+        CBF.caller.test_write_msg_2()
+        # TODO?
+        # CBF.caller.test_return_msg()
+        # CBF.caller.test_return_msg()
+        # CBF.caller.test_return_msg_2()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Following report of issue #93 I've found a workaround I thought was worth documenting. The example is so far as I know not specific to f90wrap compared to f2py but may evolve to be. At any rate I hope this is useful for a pretty common task (capturing messages to print to a jupyter notebook)  