### PR TITLE
Skip over subroutines and functions that are contained in a subroutines

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,6 +15,7 @@ EXAMPLES = arrayderivedtypes \
 	optional_derived_arrays \
 	passbyreference \
 	strings \
+	subroutine_contains_issue101 \
 	type_bn
 
 test:

--- a/examples/subroutine_contains_issue101/Makefile
+++ b/examples/subroutine_contains_issue101/Makefile
@@ -1,0 +1,21 @@
+F = gfortran 
+CFLAGS = -fPIC
+
+all: test
+
+%.o : %.f90
+	${FC} ${CFLAGS} -c $< -o $@
+
+test.o: test.f90
+
+test.py: test.o
+	f90wrap -m test test.f90
+	f2py-f90wrap -c -m _test f90wrap_toplevel.f90 test.o
+
+test: test.py
+	python run.py
+
+clean:
+	-rm -f *.o f90wrap*.f90 *.so *.mod *.pyc
+	-rm -rf __pycache__
+	-rm -f test.py

--- a/examples/subroutine_contains_issue101/run.py
+++ b/examples/subroutine_contains_issue101/run.py
@@ -1,0 +1,31 @@
+#  f90wrap: F90 to Python interface generator with derived type support
+#
+#  Copyright James Kermode 2011-2020
+#
+#  This file is part of f90wrap
+#  For the latest version see github.com/jameskermode/f90wrap
+#
+#  f90wrap is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  f90wrap is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
+# 
+#  If you would like to license the source code under different terms,
+#  please contact James Kermode, james.kermode@gmail.com
+import test
+
+assert hasattr(test, 'routine_member_procedures')
+assert not hasattr(test, 'member_procedure')
+assert not hasattr(test, 'member_function')
+
+out1, out2 = test.routine_member_procedures(1, 2)
+assert out1 == 7
+assert out2 == 23

--- a/examples/subroutine_contains_issue101/test.f90
+++ b/examples/subroutine_contains_issue101/test.f90
@@ -1,0 +1,28 @@
+subroutine routine_member_procedures(in1, in2, out1, out2)
+  ! Test member subroutine and function
+  implicit none
+  integer, intent(in) :: in1, in2
+  integer, intent(out) :: out1, out2
+  integer :: localvar 
+  
+  localvar = in2
+  call member_procedure(in1, out1)
+  out2 = member_function(out1)
+contains
+  subroutine member_procedure(in1, out1)
+    ! This member procedure shadows some variables and uses
+    ! a variable from the parent scope
+    implicit none
+    integer, intent(in) :: in1
+    integer, intent(out) :: out1
+    
+    out1 = 5 * in1 + localvar
+  end subroutine member_procedure
+  function member_function(a) result(b)
+    implicit none
+    integer, intent(in) :: a
+    integer :: b
+    
+    b = 3 * a + 2
+  end function member_function
+end subroutine routine_member_procedures

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -604,7 +604,7 @@ def check_subt(cl, file, grab_hold_doc=True):
     global hold_doc
 
     out = Subroutine()
-        
+
     if re.match(subt, cl) != None:
 
         out.filename = file.filename
@@ -662,6 +662,7 @@ def check_subt(cl, file, grab_hold_doc=True):
 
         cl = file.next()
 
+        cont = 0
         subroutine_lines = []
         while True:
 
@@ -688,29 +689,51 @@ def check_subt(cl, file, grab_hold_doc=True):
                     cl = file.next()
                     continue
 
-            # Doc comment
-            check = check_doc(cl, file)
-            if check[0] != None:
-                out.doc.append(check[0])
+            # contains statement
+            check = check_cont(cl, file)
+            if check[0] is not None:
+                cont = 1
                 cl = check[1]
-                continue
 
-            if has_args:
-                # Argument
-                check = check_arg(cl, file)
+            if cont == 0:
+
+                # Doc comment
+                check = check_doc(cl, file)
                 if check[0] != None:
-                    for a in check[0]:
-                        out.arguments.append(a)
+                    out.doc.append(check[0])
                     cl = check[1]
                     continue
 
-                # Interface section
-                check = check_interface_decl(cl, file)
-                if check[0] != None:
-                    for a in check[0].procedures:
-                        out.arguments.append(a)
+                if has_args:
+                    # Argument
+                    check = check_arg(cl, file)
+                    if check[0] != None:
+                        for a in check[0]:
+                            out.arguments.append(a)
+                        cl = check[1]
+                        continue
+
+                    # Interface section
+                    check = check_interface_decl(cl, file)
+                    if check[0] != None:
+                        for a in check[0].procedures:
+                            out.arguments.append(a)
+                        cl = check[1]
+                        continue
+
+            else:
+
+                # Subroutine definition
+                check = check_subt(cl, file)
+                if check[0] is not None:
+                    # Discard contained subroutine
                     cl = check[1]
-                    continue
+
+                # Function definition
+                check = check_funct(cl, file)
+                if check[0] is not None:
+                    # Discard contained function
+                    cl = check[1]
 
             m = subt_end.match(cl)
 


### PR DESCRIPTION
This is an attempt to fix #101.

I have no clue how robust it is, for the simple example in the issue it produces the desired result (i.e., only yields the outer subroutine but none of the inner subroutines or functions) in the Python module. Small variations (e.g., exchange order of function/subroutine) produced the same result.

Please have a look and let me know what you think!