### PR TITLE
'module procedure' was parsed without ignoring the case

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,4 @@ Contributors
 - David Verelst [davidovitch](https://github.com/davidovitch)
 - James Orr [jamesorr](https://github.com/jamesorr)
 - [yvesch](https://github.com/yvesch)
+- [Matthias Cuntz](https://github.com/mcuntz)

--- a/examples/cylinder/kind_map
+++ b/examples/cylinder/kind_map
@@ -5,6 +5,7 @@
                 '8' : 'double',
                'dp' : 'double',
               'idp' : 'double',
+              'sng_ad' : 'float',
               'dbl_ad' : 'double'},
  'complex' : {   '' : 'complex_float',
  	            '8' : 'complex_double',

--- a/examples/subroutine_contains_issue101/Makefile
+++ b/examples/subroutine_contains_issue101/Makefile
@@ -1,4 +1,4 @@
-F = gfortran 
+FC = gfortran
 CFLAGS = -fPIC
 
 all: test

--- a/f90wrap/__init__.py
+++ b/f90wrap/__init__.py
@@ -47,7 +47,7 @@ wrapping Fortran code with a simple f90 interface layer.
 
 (c) James Kermode 2011 <james.kermode@gmail.com>"""
 
-__version__ = '0.2.3a'
+__version__ = '0.2.2'
 
 import sys
 major, minor = sys.version_info[0:2]

--- a/f90wrap/__init__.py
+++ b/f90wrap/__init__.py
@@ -47,7 +47,7 @@ wrapping Fortran code with a simple f90 interface layer.
 
 (c) James Kermode 2011 <james.kermode@gmail.com>"""
 
-__version__ = '0.2.2'
+__version__ = '0.2.3a'
 
 import sys
 major, minor = sys.version_info[0:2]

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -81,7 +81,8 @@ funct = re.compile('^((' + types + r')\s+)*function', re.IGNORECASE)
 # funct       = re.compile('^function',re.IGNORECASE)
 funct_end = re.compile('^end\s*function\s*(\w*)|end$', re.IGNORECASE)
 
-prototype = re.compile(r'^module procedure ([a-zA-Z0-9_,\s]*)')
+#MC prototype = re.compile(r'^module procedure ([a-zA-Z0-9_,\s]*)')
+prototype = re.compile(r'^module procedure ([a-zA-Z0-9_,\s]*)', re.IGNORECASE)
 
 contains = re.compile('^contains', re.IGNORECASE)
 


### PR DESCRIPTION
The line
prototype = re.compile(r'^module procedure ([a-zA-Z0-9_,\s]*)')
in parser.py did not include re.IGNORECASE so 'module procedure' had to be written in lower case in order for interfaces to work.
For example:
INTERFACE sort
    MODULE PROCEDURE sort_sp, sort_dp
end interface sort
did not work.
INTERFACE sort
    module procedure sort_sp, sort_dp
end interface sort
worked.

There are four other lines fdoc_*, that deal with the documentation, that do also not ignore the case. I do not know if this is wanted or not. I am still using doxygen to document my Fortran code.

Kind regards
Matthias