### PR TITLE
fix wrapping array of derived types

### DIFF
--- a/examples/arrayderivedtypes/test.f90
+++ b/examples/arrayderivedtypes/test.f90
@@ -1,13 +1,17 @@
 module module_calcul
-type type_ptmes
-integer :: y
-end type type_ptmes
-type array_type
-type(type_ptmes) :: x(2)
-end type array_type
+  type type_ptmes
+     integer :: y
+  end type type_ptmes
+  
+  type array_type
+     type(type_ptmes) :: x(2)
+  end type array_type
+
+  type(array_type), dimension(10), target :: xarr
+  
 contains
-subroutine recup_point(x)
-type(array_type) :: x
-return
-end subroutine recup_point
+  subroutine recup_point(x)
+    type(array_type) :: x
+    return
+  end subroutine recup_point
 end module module_calcul

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -725,7 +725,7 @@ return %(el_name)s""" % dct)
                    parent='self',
                    doc=format_doc_string(el),
                    cls_name=cls_name,
-                   cls_mod_name=cls_mod_name + '.')
+                   cls_mod_name=cls_mod_name.title() + '.')
 
         if isinstance(node, ft.Module):
             dct['parent'] = 'f90wrap.runtime.empty_type'


### PR DESCRIPTION
Fix typo when generating the python class for derived arrays. 