### PR TITLE
Fix for recursive type array

### DIFF
--- a/examples/recursive_type_array/Makefile
+++ b/examples/recursive_type_array/Makefile
@@ -1,0 +1,136 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = recursive_type_array
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = test
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = test
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so test
+
+
+clean:
+	-rm -f ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}*.so \
+	 *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o ${PYTHON_MODN}.py
+	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+test: _${PYTHON_MODN}.so
+	${PYTHON} tests.py
+

--- a/examples/recursive_type_array/kind_map
+++ b/examples/recursive_type_array/kind_map
@@ -1,0 +1,14 @@
+{
+ 'real':     {'': 'float',
+              '8': 'double',
+              'dp': 'double',
+              'idp':'double'},
+ 'complex' : {'': 'complex_float',
+ 	          '8' : 'complex_double',
+ 	          '16': 'complex_long_double',
+ 	          'dp': 'complex_double'},
+ 'integer' : {'4': 'int',
+	          '8': 'long_long',
+	          'dp': 'long_long' },
+ 'character' : {'': 'char'}
+}

--- a/examples/recursive_type_array/test.f90
+++ b/examples/recursive_type_array/test.f90
@@ -1,0 +1,23 @@
+module mod_recursive_type_array
+  implicit none
+  type t_node
+    type(t_node),dimension(:),allocatable :: node
+  end type t_node
+  
+contains
+
+  subroutine allocate_node(root,N_node)
+    type(t_node) :: root
+    integer :: N_node
+
+    allocate(root%node(N_node))
+
+  end subroutine allocate_node
+
+  subroutine deallocate_node(root)
+    type(t_node) :: root
+
+    if (allocated(root%node)) deallocate(root%node)
+
+  end subroutine
+end module mod_recursive_type_array

--- a/examples/recursive_type_array/tests.py
+++ b/examples/recursive_type_array/tests.py
@@ -1,0 +1,36 @@
+"""
+Created on Mon Oct 12, 2020
+
+@author: Bernardo Pacini
+"""
+import unittest
+import numpy as np
+
+from recursive_type_array import Mod_Recursive_Type_Array as recursive_type_array
+
+class Test_recursive_type_array(unittest.TestCase):
+    def setUp(self):
+        self.N_node = 3
+
+        self.root = recursive_type_array.t_node()
+
+        recursive_type_array.allocate_node(self.root,self.N_node)
+
+    def tearDown(self):
+        recursive_type_array.deallocate_node(self.root)
+
+    def test_allocate(self):
+        self.assertEqual(
+            len(self.root.node),
+            self.N_node
+        )
+
+    def test_deallocate(self):
+        recursive_type_array.deallocate_node(self.root)
+        self.assertEqual(
+            len(self.root.node),
+            0
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Using recursion within derived types was previously address in #74, but that fix only allows for scalar recursive definitions. Defining a recursive array such as:


```
type t_node
  type(t_node),dimension(:),allocatable :: node
end type t_node
```

was not allowed and results in the errors such as:

```
f90wrap_test.f90:11:24:

   11 |     type t_node_ptr_type
      |                        1
Error: Derived type definition of 't_node_ptr_type' at (1) has already been defined
f90wrap_test.f90:13:7:

   13 |     end type t_node_ptr_type
      |       1
Error: Expecting END SUBROUTINE statement at (1)
```

This is due to the pointers to the parent and child nodes being named the same thing within the f90wrap generated Fortran code.

Adding a check for the recursive derived type (such as in #74):

```
 # Check if the type has recursive definition:
same_type = (ft.strip_type(t.name) == ft.strip_type(el.type))
```

within the `_write_array_getset_item` and `_write_array_len` identifies if the type array is recursive. Within these functions, the name of the pointer for the child can be renamed to include the tag `_rec`.  Passing the boolean `same_type`  as an optional to `write_type_lines` then allows for adding the tag `_rec` to the pointer to make the name unique.

This appears to work for my use case and the provided tests included in this PR.