### PR TITLE
proposed fix for QUIP issue 235

### DIFF
--- a/f90wrap/fortrantype.py
+++ b/f90wrap/fortrantype.py
@@ -71,11 +71,11 @@ class FortranDerivedType(object):
             init_array(self)
 
     @classmethod
-    def from_handle(cls, handle):
+    def from_handle(cls, handle, alloc=False):
         self = cls.__new__(cls)
         FortranDerivedType.__init__(self)  # always call the base constructor only
         self._handle = handle
-        self._alloc = False
+        self._alloc = alloc
         return self
 
 

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -435,7 +435,7 @@ except ValueError:
                         #         self.imports.add((self.py_mod_name + '.' + cls_mod_name, cls_name))
                         # else:
                         #     cls_name = cls_mod_name + '.' + cls_name
-                        self.write('%s = %s.from_handle(%s)' %
+                        self.write('%s = %s.from_handle(%s, alloc=True)' %
                                    (ret_val.name, cls_name, ret_val.name))
                 self.write('return %(result)s' % dct)
 


### PR DESCRIPTION
This fix should address libAtoms/QUIP#235 by transferring ownership of derived type objects allocated in Fortran back to Python for subroutines with `intent(out)` arguments of a derived type.
