### PR TITLE
Issue37 Part 1: Type procedure parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src.*
 .f2py_f2cmap
 .ipynb_checkpoints
 .idea/
+*.swp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.0)
+project(test_f90wrap)
+enable_testing()
+include(CTest)
+
+list(APPEND tests
+    arrayderivedtypes
+    arrays
+    arrays_fixed
+    arrays_in_derived_types_issue50
+    cylinder
+    derivedtypes
+    elemental
+    example2
+    extends
+    interface
+    issue105_function_definition_with_empty_lines
+    issue32
+    mockderivetype
+    mod_arg_clash
+    optional_args_issue53
+    optional_derived_arrays
+    passbyreference
+    strings
+    subroutine_contains_issue101
+    type_bn
+)
+
+foreach(test ${tests})
+    message(STATUS "Adding test ${test}")
+    add_test(
+        NAME ${test}
+        COMMAND make
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/${test}"
+    )
+endforeach()
+
+

--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -32,6 +32,8 @@ from f90wrap import fortran as ft
 from f90wrap.six import string_types  # Python 2/3 compatibility library
 from f90wrap.transform import ArrayDimensionConverter
 
+log = logging.getLogger(__name__)
+
 
 class F90WrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
     """
@@ -113,7 +115,7 @@ class F90WrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
 
         Subroutines and elements within each module are properly wrapped.
         """
-        logging.info('F90WrapperGenerator visiting module %s' % node.name)
+        log.info('F90WrapperGenerator visiting module %s' % node.name)
         self.code = []
         self.write('! Module %s defined in file %s' % (node.name, node.filename))
         self.write()
@@ -362,7 +364,7 @@ end type %(typename)s_rec_ptr_type""" % {'typename': tname})
         call_name = node.name
         if hasattr(node, 'call_name'):
             call_name = node.call_name
-        logging.info(
+        log.info(
             'F90WrapperGenerator visiting routine %s call_name %s mod_name %r' % (node.name, call_name, node.mod_name))
         self.write("subroutine %(sub_name)s%(arg_names)s" %
                    {'sub_name': self.prefix + node.name,
@@ -397,7 +399,7 @@ end type %(typename)s_rec_ptr_type""" % {'typename': tname})
         """
         Properly wraps derived types, including derived-type arrays.
         """
-        logging.info('F90WrapperGenerator visiting type %s' % node.name)
+        log.info('F90WrapperGenerator visiting type %s' % node.name)
 
         for el in node.elements:
             dims = list(filter(lambda x: x.startswith('dimension'), el.attributes))
@@ -756,7 +758,7 @@ end type %(typename)s_rec_ptr_type""" % {'typename': tname})
             String indicating whether to write a get routine, or a set routine.
         """
 
-        logging.debug('writing %s wrapper for %s.%s' % (getset, t.name, el.name))
+        log.debug('writing %s wrapper for %s.%s' % (getset, t.name, el.name))
 
         # getset and inout just change things simply from a get to a set routine.
         inout = "in"

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -276,6 +276,15 @@ class Prototype(Fortran):
     __doc__ = _rep_des(Fortran.__doc__, "Represents a Fortran Prototype.")
     pass
 
+class Binding(Fortran):
+    __doc__ = _rep_des(Fortran.__doc__, "Represents a type procedure binding.")
+    def __init__(self, name='', filename='', doc=None, lineno=0,
+                 attributes=None, type='', targets=''):
+        Fortran.__init__(self, name, filename, doc, lineno)
+        self.attributes = attributes if not None else []
+        self.targets = targets if not None else []
+        self.type = type
+
 class Declaration(Fortran):
     """
     type : `str` , default ``""``
@@ -737,7 +746,7 @@ def remove_private_symbols(node):
     """
     Walk the tree starting at *node*, removing all private symbols.
 
-    This funciton first applies the AccessUpdater transformer to
+    This function first applies the AccessUpdater transformer to
     ensure module *public_symbols* and *private_symbols* are up to
     date with *default_access* and individual `public` and `private`
     attributes.

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -276,15 +276,6 @@ class Prototype(Fortran):
     __doc__ = _rep_des(Fortran.__doc__, "Represents a Fortran Prototype.")
     pass
 
-class Binding(Fortran):
-    __doc__ = _rep_des(Fortran.__doc__, "Represents a type procedure binding.")
-    def __init__(self, name='', filename='', doc=None, lineno=0,
-                 attributes=None, type='', targets=''):
-        Fortran.__init__(self, name, filename, doc, lineno)
-        self.attributes = attributes if not None else []
-        self.targets = targets if not None else []
-        self.type = type
-
 class Declaration(Fortran):
     """
     type : `str` , default ``""``
@@ -360,6 +351,36 @@ class Interface(Fortran):
         if procedures is None:
             procedures = []
         self.procedures = procedures
+        self.mod_name = mod_name
+        self.type_name = type_name
+
+class Binding(Fortran):
+    """
+    type : `str`, default ``None``
+        The type of bound procedures: ['procedure', 'generic', 'final']
+
+    attributes : list of `str`, default ``[]``
+        Attributes of the procedure
+
+    procedures : list of :class:`fortran.Procedure`, default ``[]``
+        The procedures listed in the binding.
+
+    mod_name : `str` , default ``None``
+        The name of the module in which the interface is found, if any.
+
+    type_name : `str` , default ``None``
+        The name of the type in which the interface is defined, if any.
+    """
+    __doc__ = _rep_des(Fortran.__doc__, "Represents a Derived Type procedure binding.") + __doc__
+    _fields = ['procedures']
+
+    __doc__ = _rep_des(Fortran.__doc__, "Represents a type procedure binding.")
+    def __init__(self, name='', filename='', doc=None, lineno=0,
+                 type=None, attributes=None, procedures=None, mod_name=None, type_name=None):
+        Fortran.__init__(self, name, filename, doc, lineno)
+        self.type = type
+        self.attributes = attributes if procedures else []
+        self.procedures = procedures if procedures else []
         self.mod_name = mod_name
         self.type_name = type_name
 

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -32,6 +32,9 @@ import re
 
 import numpy as np
 
+log = logging.getLogger(__name__)
+
+
 def _rep_des(doc, string):
     """
     Replaces the description line of a documentation with `string`
@@ -596,14 +599,14 @@ def find_types(tree, skipped_types=None):
         for node in walk(mod):
             if isinstance(node, Type):
                 if node.name not in skipped_types:
-                    logging.debug('type %s defined in module %s' % (node.name, mod.name))
+                    log.debug('type %s defined in module %s' % (node.name, mod.name))
                     node.mod_name = mod.name  # save module name in Type instance
                     node.uses = set([(mod.name, (node.name,))])
                     types[node.name] = node
                     types['type(%s)' % node.name] = node
                     types['class(%s)' % node.name] = node
                 else:
-                    logging.info('Skipping type %s defined in module %s' % (node.name, mod.name))
+                    log.info('Skipping type %s defined in module %s' % (node.name, mod.name))
 
     return types
 
@@ -709,12 +712,12 @@ class AccessUpdater(FortranTransformer):
 
                 # symbol should be marked as public if it's not already
                 if node.name not in self.mod.public_symbols:
-                    logging.debug('marking public symbol ' + node.name)
+                    log.debug('marking public symbol ' + node.name)
                     self.mod.public_symbols.append(node.name)
             else:
                 # symbol should be marked as private if it's not already
                 if node.name not in self.mod.private_symbols:
-                    logging.debug('marking private symbol ' + node.name)
+                    log.debug('marking private symbol ' + node.name)
                     self.mod.private_symbols.append(node.name)
 
         elif self.mod.default_access == 'private':
@@ -723,12 +726,12 @@ class AccessUpdater(FortranTransformer):
 
                 # symbol should be marked as private if it's not already
                 if node.name not in self.mod.private_symbols:
-                    logging.debug('marking private symbol ' + node.name)
+                    log.debug('marking private symbol ' + node.name)
                     self.mod.private_symbols.append(node.name)
             else:
                 # symbol should be marked as public if it's not already
                 if node.name not in self.mod.public_symbols:
-                    logging.debug('marking public symbol ' + node.name)
+                    log.debug('marking public symbol ' + node.name)
                     self.mod.public_symbols.append(node.name)
 
         else:
@@ -757,7 +760,7 @@ class PrivateSymbolsRemover(FortranTransformer):
             return self.generic_visit(node)
 
         if node.name in self.mod.private_symbols:
-            logging.debug('removing private symbol ' + node.name)
+            log.debug('removing private symbol ' + node.name)
             return None
         else:
             return node

--- a/f90wrap/latex.py
+++ b/f90wrap/latex.py
@@ -17,7 +17,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 
@@ -50,6 +50,8 @@ from f90wrap import fortran as ft
 
 import sys
 major, minor = sys.version_info[0:2]
+
+log = logging.getLogger(__name__)
 
 if (major, minor) < (2, 5):
     all = lambda seq: not False in seq
@@ -661,7 +663,7 @@ class LatexGenerator(ft.FortranVisitor, LatexOutput):
             return
 
         if any([isinstance(proc, ft.Prototype) for proc in node.procedures]):
-            logging.debug('Skipping interface %s as some procedures were not found' % node.name)
+            log.debug('Skipping interface %s as some procedures were not found' % node.name)
             return
 
         n_sub = sum([isinstance(proc, ft.Subroutine) for proc in node.procedures])

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -65,7 +65,8 @@ type_end = re.compile('^end\s*type|end$', re.IGNORECASE)
 
 dummy_types_re = re.compile('recursive|pure|elemental', re.IGNORECASE)
 
-types = r'recursive|pure|double precision|elemental|(real\s*(\(.*?\))?)|(complex\s*(\(.*?\))?)|(integer\s*(\(.*?\))?)|(logical)|(character\s*(\(.*?\))?)|(type\s*\().*?(\))|(class\s*\().*?(\))'
+prefixes = r'elemental|impure|module|non_recursive|pure|recursive'
+types = r'double precision|(real\s*(\(.*?\))?)|(complex\s*(\(.*?\))?)|(integer\s*(\(.*?\))?)|(logical)|(character\s*(\(.*?\))?)|(type\s*\().*?(\))|(class\s*\().*?(\))'
 a_attribs = r'allocatable|pointer|save|dimension\(.*?\)|intent\(.*?\)|optional|target|public|private'
 
 types_re = re.compile(types, re.IGNORECASE)
@@ -78,10 +79,10 @@ c_ret = re.compile(r'\r')
 iface = re.compile('^interface', re.IGNORECASE)
 iface_end = re.compile('^end\s*interface|end$', re.IGNORECASE)
 
-subt = re.compile(r'^(recursive\s+)?subroutine', re.IGNORECASE)
+subt = re.compile(r'^((' + prefixes + r')\s+)*subroutine', re.IGNORECASE)
 subt_end = re.compile(r'^end\s*subroutine\s*(\w*)|end$', re.IGNORECASE)
 
-funct = re.compile('^((' + types + r')\s+)*function', re.IGNORECASE)
+funct = re.compile(r'^((' + types + '|' + prefixes + r')\s+)*function', re.IGNORECASE)
 # funct       = re.compile('^function',re.IGNORECASE)
 funct_end = re.compile('^end\s*function\s*(\w*)|end$', re.IGNORECASE)
 

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -511,6 +511,7 @@ def check_module(cl, file):
                 check = check_interface(cl, file)
                 if check[0] != None:
                     logging.debug('    interface ' + check[0].name)
+                    check[0].mod_name = out.name
                     out.interfaces.append(check[0])
                     cl = check[1]
                     continue
@@ -519,6 +520,7 @@ def check_module(cl, file):
                 check = check_type(cl, file)
                 if check[0] != None:
                     logging.debug('    type ' + check[0].name)
+                    check[0].mod_name = out.name
                     out.types.append(check[0])
                     cl = check[1]
                     continue
@@ -572,6 +574,7 @@ def check_module(cl, file):
                 check = check_subt(cl, file)
                 if check[0] != None:
                     logging.debug('    module subroutine ' + check[0].name)
+                    check[0].mod_name = out.name
                     out.procedures.append(check[0])
                     cl = check[1]
                     continue
@@ -580,6 +583,7 @@ def check_module(cl, file):
                 check = check_funct(cl, file)
                 if check[0] != None:
                     logging.debug('    module function ' + check[0].name)
+                    check[0].mod_name = out.name
                     out.procedures.append(check[0])
                     cl = check[1]
                     continue
@@ -1075,7 +1079,7 @@ def check_type(cl, file):
 
                 check = check_binding(cl, file)
                 if check[0] != None:
-                    out.procedures.extend(check[0])
+                    out.bindings.extend(check[0])
                     cl = check[1]
                     continue
 

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -40,11 +40,15 @@
 # Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307 USA
 
+import logging
 import string
 import sys
 import os
 
 from f90wrap.fortran import *       #fixme: remove star import
+
+log = logging.getLogger(__name__)
+
 
 # Define some regular expressions
 
@@ -426,7 +430,7 @@ def check_program(cl, file):
                 # Subroutine definition
                 check = check_subt(cl, file)
                 if check[0] != None:
-                    logging.debug('    program subroutine ' + check[0].name)
+                    log.debug('    program subroutine ' + check[0].name)
                     out.procedures.append(check[0])
                     cl = check[1]
                     continue
@@ -434,7 +438,7 @@ def check_program(cl, file):
                 # Function definition
                 check = check_funct(cl, file)
                 if check[0] != None:
-                    logging.debug('    program function ' + check[0].name)
+                    log.debug('    program function ' + check[0].name)
                     out.procedures.append(check[0])
                     cl = check[1]
                     continue
@@ -510,7 +514,7 @@ def check_module(cl, file):
                 # jrk33 - Interface definition
                 check = check_interface(cl, file)
                 if check[0] != None:
-                    logging.debug('    interface ' + check[0].name)
+                    log.debug('    interface ' + check[0].name)
                     check[0].mod_name = out.name
                     out.interfaces.append(check[0])
                     cl = check[1]
@@ -519,7 +523,7 @@ def check_module(cl, file):
                 # Type definition
                 check = check_type(cl, file)
                 if check[0] != None:
-                    logging.debug('    type ' + check[0].name)
+                    log.debug('    type ' + check[0].name)
                     check[0].mod_name = out.name
                     out.types.append(check[0])
                     cl = check[1]
@@ -538,7 +542,7 @@ def check_module(cl, file):
                 if m is not None:
                     line = m.group()
                     if line.lower() == 'public':
-                        logging.info('marking module %s as default public' % out.name)
+                        log.info('marking module %s as default public' % out.name)
                         out.default_access = 'public'
                     else:
                         line = line.lower().replace('public', '')
@@ -550,7 +554,7 @@ def check_module(cl, file):
                 if m is not None:
                     line = m.group()
                     if line.lower() == 'private':
-                        logging.info('marking module %s as default private' % out.name)
+                        log.info('marking module %s as default private' % out.name)
                         out.default_access = 'private'
                     else:
                         line = line.replace('private', '')
@@ -573,7 +577,7 @@ def check_module(cl, file):
                 # Subroutine definition
                 check = check_subt(cl, file)
                 if check[0] != None:
-                    logging.debug('    module subroutine ' + check[0].name)
+                    log.debug('    module subroutine ' + check[0].name)
                     check[0].mod_name = out.name
                     out.procedures.append(check[0])
                     cl = check[1]
@@ -582,7 +586,7 @@ def check_module(cl, file):
                 # Function definition
                 check = check_funct(cl, file)
                 if check[0] != None:
-                    logging.debug('    module function ' + check[0].name)
+                    log.debug('    module function ' + check[0].name)
                     check[0].mod_name = out.name
                     out.procedures.append(check[0])
                     cl = check[1]
@@ -620,7 +624,7 @@ def check_subt(cl, file, grab_hold_doc=True):
         # Get subt name
         cl = subt.sub('', cl)
         out.name = re.search(re.compile('\w+'), cl).group()
-        logging.debug('    module subroutine checking ' + out.name)
+        log.debug('    module subroutine checking ' + out.name)
 
         # Test in principle whether we can have a 'do not wrap' list
         if out.name.lower() == 'debugtype_stop_if':
@@ -804,7 +808,7 @@ def implicit_to_explicit_arguments(argl, ag_temp):
 def implicit_type_rule(var):
     # YANN: implicit arguments type rule
     tp = 'integer' if var[0] in ('i', 'j', 'k', 'l', 'm', 'n') else 'real'
-    logging.debug('        implicit type of "%s" inferred from its name as "%s"' % (var, tp))
+    log.debug('        implicit type of "%s" inferred from its name as "%s"' % (var, tp))
     return tp
 
 
@@ -847,7 +851,7 @@ def check_funct(cl, file, grab_hold_doc=True):
 
         cl = funct.sub('', cl)
         out.name = re.search(re.compile('\w+'), cl).group()
-        logging.debug('    module function checking ' + out.name)
+        log.debug('    module function checking ' + out.name)
 
         # Default name of return value is function name
         out.ret_val.name = out.name
@@ -1042,7 +1046,7 @@ def check_type(cl, file):
             out.attributes = split_attribs(m.group(1))
 
         out.name = re.search(re.compile('\w+'), cl).group()
-        logging.info('parser reading type %s' % out.name)
+        log.info('parser reading type %s' % out.name)
 
         # Get next line, and check each possibility in turn
 
@@ -1053,7 +1057,7 @@ def check_type(cl, file):
             # contains statement
             check = check_cont(cl, file)
             if check[0] != None:
-                logging.debug('parser reading type %s bound procedures', out.name)
+                log.debug('parser reading type %s bound procedures', out.name)
                 cont = 1
                 cl = check[1]
                 continue
@@ -1211,7 +1215,7 @@ def check_binding(cl, file):
         if type == 'generic':
             name, targets = bindings.split('=>')
             name = name.strip().lower()
-            logging.debug('found generic binding %s => %s', name, targets)
+            log.debug('found generic binding %s => %s', name, targets)
             out.append(Binding(
                 name=name,
                 lineno=file.lineno,
@@ -1232,7 +1236,7 @@ def check_binding(cl, file):
                 name, *target = [ word.strip().lower() for word in b.split('=>')]
                 name = name.strip().lower()
                 target = target[0] if target else name
-                logging.debug('found %s binding %s => %s', type, name, target)
+                log.debug('found %s binding %s => %s', type, name, target)
                 out.append(Binding(
                     name=name,
                     lineno=file.lineno,
@@ -1437,7 +1441,7 @@ def read_files(args, doc_plugin_filename=None):
 
         # Open the filename for reading
 
-        logging.debug('processing file ' + fname)
+        log.debug('processing file ' + fname)
         file = F90File(fname)
 
         # Get first line
@@ -1449,7 +1453,7 @@ def read_files(args, doc_plugin_filename=None):
             # programs
             check = check_program(cline, file)
             if check[0] != None:
-                logging.debug('  program ' + check[0].name)
+                log.debug('  program ' + check[0].name)
                 root.programs.append(check[0])
                 cline = check[1]
                 continue
@@ -1457,7 +1461,7 @@ def read_files(args, doc_plugin_filename=None):
             # modules
             check = check_module(cline, file)
             if check[0] != None:
-                logging.debug('  module ' + check[0].name)
+                log.debug('  module ' + check[0].name)
                 root.modules.append(check[0])
                 cline = check[1]
                 continue
@@ -1475,7 +1479,7 @@ def read_files(args, doc_plugin_filename=None):
             # stand-alone subroutines
             check = check_subt(cline, file)
             if check[0] != None:
-                # logging.debug('  subroutine ' + check[0].name)
+                # log.debug('  subroutine ' + check[0].name)
                 root.procedures.append(check[0])
                 cline = check[1]
                 continue
@@ -1483,7 +1487,7 @@ def read_files(args, doc_plugin_filename=None):
             # stand-alone functions
             check = check_funct(cline, file)
             if check[0] != None:
-                # logging.debug('  function ' + check[0].name)
+                # log.debug('  function ' + check[0].name)
                 root.procedures.append(check[0])
                 cline = check[1]
                 continue

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -17,7 +17,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 
@@ -29,6 +29,7 @@ from f90wrap.transform import ArrayDimensionConverter
 from f90wrap import fortran as ft
 from f90wrap import codegen as cg
 
+log = logging.getLogger(__name__)
 
 def py_arg_value(arg):
     # made global from PythonWrapperGenerator.visit_Procedure so that other functions can use it
@@ -220,7 +221,7 @@ class PythonWrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
         py_wrapper_file.close()
 
     def visit_Module(self, node):
-        logging.info('PythonWrapperGenerator visiting module %s' % node.name)
+        log.info('PythonWrapperGenerator visiting module %s' % node.name)
         cls_name = normalise_class_name(node.name, self.class_names)
         node.array_initialisers = []
         node.dt_array_initialisers = []
@@ -386,7 +387,7 @@ except ValueError:
 
     def visit_Procedure(self, node):
 
-        logging.info('PythonWrapperGenerator visiting routine %s' % node.name)
+        log.info('PythonWrapperGenerator visiting routine %s' % node.name)
         if 'classmethod' in node.attributes:
             self.write_classmethod(node)
         elif 'constructor' in node.attributes:
@@ -443,7 +444,7 @@ except ValueError:
             self.write()
 
     def visit_Interface(self, node):
-        logging.info('PythonWrapperGenerator visiting interface %s' % node.name)
+        log.info('PythonWrapperGenerator visiting interface %s' % node.name)
 
         # first output all the procedures within the interface
         self.generic_visit(node)
@@ -488,7 +489,7 @@ except ValueError:
         self.write()
 
     def visit_Type(self, node):
-        logging.info('PythonWrapperGenerator visiting type %s' % node.name)
+        log.info('PythonWrapperGenerator visiting type %s' % node.name)
         node.dt_array_initialisers = []
         cls_name = normalise_class_name(node.name, self.class_names)
         self.write('@f90wrap.runtime.register_class("%s.%s")' % (self.py_mod_name, cls_name))

--- a/scripts/f90wrap
+++ b/scripts/f90wrap
@@ -20,7 +20,7 @@
 
   You should have received a copy of the GNU Lesser General Public License
   along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
- 
+
   If you would like to license the source code under different terms,
   please contact James Kermode, james.kermode@gmail.com
 """
@@ -48,6 +48,7 @@ from f90wrap import transform as tf
 from f90wrap import f90wrapgen as fwrap
 from f90wrap import pywrapgen as pywrap
 
+logging.basicConfig(stream=sys.stdout)
 
 class CLIError(Exception):
     '''Generic exception to raise and log different fatal errors.'''
@@ -158,9 +159,9 @@ USAGE
         args = parser.parse_args()
 
         if args.verbose:
-            logging.root.setLevel(logging.DEBUG)
+            logging.getLogger().setLevel(logging.DEBUG)
         else:
-            logging.root.setLevel(logging.INFO)
+            logging.getLogger().setLevel(logging.INFO)
 
         # set defaults, to be overridden by command line args and config file
         kind_map = {}

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+test.log

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,10 @@
+import logging
+from pathlib import Path
+
+test_dir = Path(__file__).parent.resolve()
+test_samples_dir = test_dir/'samples'
+
+log_file = test_dir/'test.log'
+if log_file.exists():
+    log_file.unlink()
+logging.basicConfig(filename=log_file,level=logging.DEBUG)

--- a/test/samples/circle.f90
+++ b/test/samples/circle.f90
@@ -1,0 +1,60 @@
+! Adapted from http://fortranwiki.org/fortran/show/Object-oriented+programming
+module ClassCircle
+  implicit none
+  private
+
+  real :: pi = 3.14159
+
+  type, public :: Circle
+    private
+    real :: radius
+    real :: area
+  contains
+    procedure :: get_area => Circle_get_area
+    procedure :: get_radius => Circle_get_radius
+    procedure :: print => Circle_print
+    final :: Circle_finalize
+  end type
+  interface Circle
+    module procedure :: Circle_initialize
+  end interface
+
+contains
+
+  function Circle_initialize(radius) result(this)
+    type(Circle) :: this
+    real, intent(in) :: radius
+    this%radius = radius
+    this%area = pi * radius * radius
+    write(*,*) 'Initialize Circle'
+    return
+  end function
+
+  subroutine Circle_finalize(this)
+    type(Circle), intent(inout) :: this
+    write(*,*) 'Finalizing Circle'
+    return
+  end subroutine
+
+  function Circle_get_area(this) result(area)
+    class(Circle), intent(in) :: this
+    real :: area
+    area = this%area
+    return
+  end function
+
+  function Circle_get_radius(this) result(radius)
+    class(Circle), intent(in) :: this
+    real :: radius
+    radius = this%radius
+    return
+  end function
+
+  subroutine circle_print(this)
+    class(Circle), intent(in) :: this
+    write(*,*) 'Circle: r = ', this%radius, ' area = ', this%area
+    return
+  end subroutine
+
+end module
+

--- a/test/samples/circle.f90
+++ b/test/samples/circle.f90
@@ -1,4 +1,3 @@
-! Adapted from http://fortranwiki.org/fortran/show/Object-oriented+programming
 module ClassCircle
   implicit none
   private
@@ -7,34 +6,59 @@ module ClassCircle
 
   type, public :: Circle
     private
+    character(:), allocatable :: name
     real :: radius
     real :: area
   contains
     procedure :: get_area => Circle_get_area
     procedure :: get_radius => Circle_get_radius
-    procedure :: print_basic => Circle_print_basic, &
-                 print_tagged => Circle_print_tagged
+    procedure, private, non_overridable :: &
+      print_basic => Circle_print_basic,   &
+      print_tagged => Circle_print_tagged
     generic :: print => print_basic, print_tagged
     final :: Circle_finalize
+    final :: Circle_finalize_array
   end type
   interface Circle
-    module procedure :: Circle_initialize
+    module procedure :: Circle_initialize_named
+    module procedure :: Circle_initialize_unnamed
   end interface
 
 contains
 
-  function Circle_initialize(radius) result(this)
+  function Circle_initialize_named(name, radius) result(this)
     type(Circle) :: this
+    character(*), intent(in) :: name
     real, intent(in) :: radius
+    this%name = name
     this%radius = radius
     this%area = pi * radius * radius
-    write(*,*) 'Initialize Circle'
+    write(*,*) 'Circle(', this%name, '): Construct w/ name'
+    return
+  end function
+
+  function Circle_initialize_unnamed(radius) result(this)
+    type(Circle) :: this
+    real, intent(in) :: radius
+    this%name = 'unnamed'
+    this%radius = radius
+    this%area = pi * radius * radius
+    write(*,*) 'Circle(unnamed): Construct w/o name'
     return
   end function
 
   subroutine Circle_finalize(this)
     type(Circle), intent(inout) :: this
-    write(*,*) 'Finalizing Circle'
+    write(*,*) 'Circle(', this%name, '): Destruct'
+    return
+  end subroutine
+
+  subroutine Circle_finalize_array(this_arr)
+    type(Circle), intent(inout) :: this_arr(:)
+    integer :: i
+    do i = 1, size(this_arr)
+      write(*,*) 'Circle(', this_arr(i)%name, '): Destruct'
+    end do
     return
   end subroutine
 
@@ -42,6 +66,7 @@ contains
     class(Circle), intent(in) :: this
     real :: area
     area = this%area
+    write(*,*) 'Circle(', this%name, '): Get Area'
     return
   end function
 
@@ -49,19 +74,20 @@ contains
     class(Circle), intent(in) :: this
     real :: radius
     radius = this%radius
+    write(*,*) 'Circle(', this%name, '): Get Radius'
     return
   end function
 
   subroutine circle_print_basic(this)
     class(Circle), intent(in) :: this
-    write(*,*) 'Circle: r = ', this%radius, ' area = ', this%area
+    write(*,*) 'Circle(', this%name, '): r = ', this%radius, ' area = ', this%area
     return
   end subroutine
 
   subroutine circle_print_tagged(this, tag)
     class(Circle), intent(in) :: this
     character(*), intent(in) :: tag
-    write(*,*) 'Circle [', tag, ']: r = ', this%radius, ' area = ', this%area
+    write(*,*) 'Circle(', this%name, ') [', tag, ']: r = ', this%radius, ' area = ', this%area
     return
   end subroutine
 

--- a/test/samples/circle.f90
+++ b/test/samples/circle.f90
@@ -1,10 +1,9 @@
 module ClassCircle
   implicit none
-  private
 
-  real :: pi = 3.14159
+  real, private :: pi = 3.14159
 
-  type, public :: Circle
+  type :: Circle
     private
     character(:), allocatable :: name
     real :: radius
@@ -17,16 +16,16 @@ module ClassCircle
       print_tagged => Circle_print_tagged
     generic :: print => print_basic, print_tagged
     final :: Circle_finalize
-    final :: Circle_finalize_array
+    final :: Circle_array_finalize
   end type
   interface Circle
-    module procedure :: Circle_initialize_named
-    module procedure :: Circle_initialize_unnamed
+    module procedure :: Circle_named_initialize
+    module procedure :: Circle_unnamed_initialize
   end interface
 
 contains
 
-  function Circle_initialize_named(name, radius) result(this)
+  function Circle_named_initialize(name, radius) result(this)
     type(Circle) :: this
     character(*), intent(in) :: name
     real, intent(in) :: radius
@@ -37,7 +36,7 @@ contains
     return
   end function
 
-  function Circle_initialize_unnamed(radius) result(this)
+  function Circle_unnamed_initialize(radius) result(this)
     type(Circle) :: this
     real, intent(in) :: radius
     this%name = 'unnamed'
@@ -53,7 +52,7 @@ contains
     return
   end subroutine
 
-  subroutine Circle_finalize_array(this_arr)
+  subroutine Circle_array_finalize(this_arr)
     type(Circle), intent(inout) :: this_arr(:)
     integer :: i
     do i = 1, size(this_arr)

--- a/test/samples/circle.f90
+++ b/test/samples/circle.f90
@@ -12,7 +12,9 @@ module ClassCircle
   contains
     procedure :: get_area => Circle_get_area
     procedure :: get_radius => Circle_get_radius
-    procedure :: print => Circle_print
+    procedure :: print_basic => Circle_print_basic, &
+                 print_tagged => Circle_print_tagged
+    generic :: print => print_basic, print_tagged
     final :: Circle_finalize
   end type
   interface Circle
@@ -50,9 +52,16 @@ contains
     return
   end function
 
-  subroutine circle_print(this)
+  subroutine circle_print_basic(this)
     class(Circle), intent(in) :: this
     write(*,*) 'Circle: r = ', this%radius, ' area = ', this%area
+    return
+  end subroutine
+
+  subroutine circle_print_tagged(this, tag)
+    class(Circle), intent(in) :: this
+    character(*), intent(in) :: tag
+    write(*,*) 'Circle [', tag, ']: r = ', this%radius, ' area = ', this%area
     return
   end subroutine
 

--- a/test/samples/test_circle.f90
+++ b/test/samples/test_circle.f90
@@ -1,0 +1,11 @@
+program test_circle
+  use ClassCircle
+  block
+    ! Use block so destructor fires
+    type(Circle) :: c
+    c = Circle(5.0)
+    write(*,*) 'get_area:   ', c%get_area()
+    write(*,*) 'get_radius: ', c%get_radius()
+    call c%print()
+  end block
+end program

--- a/test/samples/test_circle.f90
+++ b/test/samples/test_circle.f90
@@ -1,11 +1,20 @@
 program test_circle
   use ClassCircle
   block
+
     ! Use block so destructor fires
     type(Circle) :: c
+    double precision :: x
+
     c = Circle(5.0)
-    write(*,*) 'get_area:   ', c%get_area()
-    write(*,*) 'get_radius: ', c%get_radius()
+    x = c%get_area()
+    x = c%get_radius()
     call c%print()
+
+    c =  Circle('test', 3.0)
+    x = c%get_area()
+    x = c%get_radius()
+    call c%print('tag')
+
   end block
 end program

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -17,3 +17,10 @@ class TestParser(unittest.TestCase):
         self.assertEqual(bindings[4].name, 'print')
         self.assertEqual(len(bindings[4].procedures), 2)
         self.assertEqual(bindings[5].type, 'final')
+
+    def test_parse_dnad(self):
+        root = parser.read_files([str(test_samples_dir/'DNAD.fpp')])
+        proc_names = [ p.name for p in root.modules[0].procedures ]
+        self.assertIn('abs_d', proc_names)
+        self.assertIn('add_di', proc_names)
+        self.assertIn('assign_di', proc_names)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -7,8 +7,7 @@ class TestParser(unittest.TestCase):
 
     def test_parse_type_procedures(self):
         root = parser.read_files([str(test_samples_dir/'circle.f90')])
-        parser.dump(root)
-        bindings = root.modules[0].types[0].procedures
+        bindings = root.modules[0].types[0].bindings
         self.assertEqual(len(bindings), 7)
         self.assertEqual(bindings[0].type, 'procedure')
         self.assertEqual(bindings[0].name, 'get_area')

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -2,10 +2,17 @@ import unittest
 from f90wrap import parser
 from . import test_samples_dir
 
+
 class TestParser(unittest.TestCase):
 
     def test_parse_type_procedures(self):
         root = parser.read_files([str(test_samples_dir/'circle.f90')])
         type_procedures = root.modules[0].types[0].procedures
-        self.assertEquals(len(type_procedures), 4)
-
+        self.assertEqual(len(type_procedures), 6)
+        self.assertEqual(type_procedures[0].type, 'procedure')
+        self.assertEqual(type_procedures[0].name, 'get_area')
+        self.assertEqual(type_procedures[0].targets, ['circle_get_area'])
+        self.assertEqual(type_procedures[4].type, 'generic')
+        self.assertEqual(type_procedures[4].name, 'print')
+        self.assertEqual(type_procedures[4].targets, ['print_basic', 'print_tagged'])
+        self.assertEqual(type_procedures[5].type, 'final')

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,11 @@
+import unittest
+from f90wrap import parser
+from . import test_samples_dir
+
+class TestParser(unittest.TestCase):
+
+    def test_parse_type_procedures(self):
+        root = parser.read_files([str(test_samples_dir/'circle.f90')])
+        type_procedures = root.modules[0].types[0].procedures
+        self.assertEquals(len(type_procedures), 4)
+

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -7,12 +7,14 @@ class TestParser(unittest.TestCase):
 
     def test_parse_type_procedures(self):
         root = parser.read_files([str(test_samples_dir/'circle.f90')])
-        type_procedures = root.modules[0].types[0].procedures
-        self.assertEqual(len(type_procedures), 6)
-        self.assertEqual(type_procedures[0].type, 'procedure')
-        self.assertEqual(type_procedures[0].name, 'get_area')
-        self.assertEqual(type_procedures[0].targets, ['circle_get_area'])
-        self.assertEqual(type_procedures[4].type, 'generic')
-        self.assertEqual(type_procedures[4].name, 'print')
-        self.assertEqual(type_procedures[4].targets, ['print_basic', 'print_tagged'])
-        self.assertEqual(type_procedures[5].type, 'final')
+        parser.dump(root)
+        bindings = root.modules[0].types[0].procedures
+        self.assertEqual(len(bindings), 7)
+        self.assertEqual(bindings[0].type, 'procedure')
+        self.assertEqual(bindings[0].name, 'get_area')
+        self.assertEqual(bindings[2].attributes, ['private', 'non_overridable'])
+        self.assertEqual(bindings[0].procedures[0].name, 'circle_get_area')
+        self.assertEqual(bindings[4].type, 'generic')
+        self.assertEqual(bindings[4].name, 'print')
+        self.assertEqual(len(bindings[4].procedures), 2)
+        self.assertEqual(bindings[5].type, 'final')

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -18,6 +18,17 @@ class TestTransform(unittest.TestCase):
             fortran.Function
         ))
 
+    def test_parse_dnad(self):
+        root = parser.read_files([str(test_samples_dir/'DNAD.fpp')])
+        new = transform.ResolveInterfacePrototypes().visit(root)
+        m = new.modules[0]
+        self.assertEqual(len(m.procedures), 1)
+        # TODO: Fix incomplete resolution of prototypes
+        #       This is because both interfaces reference the same procedure
+        #       but we only resolve first reference of a given procedure.
+        self.assertIsInstance(m.interfaces[12].procedures[0], fortran.Function)
+        self.assertIsInstance(m.interfaces[13].procedures[0], fortran.Prototype)
+
     def test_resolve_binding_prototypes(self):
         ''' Verify procedures gets moved into binding objects '''
         new = transform.ResolveBindingPrototypes().visit(self.root)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1,0 +1,72 @@
+import unittest
+from f90wrap import fortran, parser, transform
+from . import test_samples_dir
+
+
+class TestTransform(unittest.TestCase):
+
+    def setUp(self):
+        self.root = parser.read_files([str(test_samples_dir/'circle.f90')])
+
+    def test_resolve_interface_prototypes(self):
+        ''' Verify procedures gets moved into interface objects '''
+        new = transform.ResolveInterfacePrototypes().visit(self.root)
+        m = new.modules[0]
+        self.assertEqual(len(m.procedures), 6)
+        self.assertTrue(isinstance(
+            m.interfaces[0].procedures[0],
+            fortran.Function
+        ))
+
+    def test_resolve_binding_prototypes(self):
+        ''' Verify procedures gets moved into binding objects '''
+        new = transform.ResolveBindingPrototypes().visit(self.root)
+        m = new.modules[0]
+        t = m.types[0]
+        b_normal = t.bindings[0]
+        b_generic = t.bindings[2]
+        b_final = t.bindings[3]
+        self.assertEqual(len(m.procedures), 2)
+        self.assertEqual(len(b_normal.procedures), 1)
+        self.assertEqual(len(b_generic.procedures), 2)
+        self.assertIn('destructor', b_final.attributes)
+        self.assertTrue(isinstance(
+            b_normal.procedures[0],
+            fortran.Function
+        ))
+
+    def test_bind_constructor_interfaces(self):
+        ''' Verify interfaces with same name as type become constructors '''
+        new = transform.ResolveInterfacePrototypes().visit(self.root)
+        new = transform.BindConstructorInterfaces().visit(new)
+        m = new.modules[0]
+        t = m.types[0]
+        self.assertEqual(len(m.interfaces), 0)
+        self.assertEqual(len(t.interfaces), 1)
+        self.assertIn('constructor', t.interfaces[0].attributes)
+
+    def test_generic_tranform(self):
+        types = fortran.find_types(self.root)
+        mods  = { type.mod_name: type.mod_name for _,type in types.items()}
+        new = transform.transform_to_generic_wrapper(self.root,
+            types=types,
+            callbacks=[],
+            constructors=[],
+            destructors=[],
+            short_names={},
+            init_lines={},
+            kept_subs=[],
+            kept_mods=[],
+            argument_name_map={},
+            move_methods=True,
+            shorten_routine_names=[],
+            modules_for_type=mods,
+            remove_optional_arguments=False,
+            force_public=[],
+        )
+        m = new.modules[0]
+        t = m.types[0]
+        self.assertEqual(len(m.procedures), 0)
+        self.assertEqual(len(t.elements), 0)
+        self.assertEqual(len(t.bindings), 4)
+        self.assertEqual(len(t.interfaces), 1)


### PR DESCRIPTION
Hello and Happy Thanksgiving! 

I am planning to wrap a Fortran codebase, some of which uses object-oriented style with type-bound procedures. I see that is not yet supported in f90wrap (per #37), but the bones look good, so I've started the work to add basic support for (non-polymorphic) object oriented Fortran. This pull request is a work-in-progress to solicit feed back on the design so far. 

The major changes to the code are as follows:

1. The parser now reads the `contains` section of a derived type.
2. There is now a `Binding` node type which represents "regular", "generic", or "final" type-bound procedures. Like Interfaces, each Binding is initially populated with one (or more, in the case of a generic binding) Prototypes to represent which module procedures are associated with a given type-bound procedure name.
3. The `Type` node now has a list of Bindings. 
4. The `Interface` node now has a list of attributes.
5. A new pass has been added to `transform_to_generic_wrapper` to resolve Prototypes that appear in Bindings nodes. If a Binding is "final", that Binding and it's procedures get marked as `destructor`s.
6. For uniformity, resolution of Interface Prototypes has moved out of the parser into `transform_generic_wrapper`.
7. A new pass has been added to `transform_to_generic_wrapper` to promote Interfaces that alias existing derived types into that type's Interface list and mark it and it's procedures as `constructor`s.

Limitations:

1. No code generation yet. Just construction of the generic AST with full resolution of type-bound procedures, constructors and destructors.
2. Procedure definitions may only be referenced once in the set of Interfaces and Bindings (see below).
3. No support for inheritance/polymorphism, e.g. `extends` (and none planned, for now).

Issues: 

1. The main issue I'd like some insight/guidance on is how to handle procedure definitions that are referenced in multiple Interfaces/Bindings. This is allowed by the standard, but the current parser does not support this: it associates a Procedure with its first reference in the module's Interfaces and ignore any subsequent references. Injecting the Procedure at all reference points leads to name clashes in the generated Fortran wrapper code. I suspect this could be resolved by adding the Interface/Binding name into the "mangled" name of the wrapper function, but I haven't explored this much. If there are other suggestions for how to tackle this, please let me know.

Other changes: 

1. All subroutine prefixes, e.g. 'elemental', are now supported. Previously, only the 'recursive' prefix was recognized. Other prefixes would cause the subroutine to be bypassed during parsing. 
2. I did a bit of cleanup to the printing and logging. Modules now use module-specific loggers, as opposed to the root logger.
3. I added a CMakeLists file to the examples directory so the examples can be run via CTest. This makes it a bit easier to suppress test output, run a subset of tests, see what failed, re-run only failed tests, etc. If there's interest, I may add full CMake support so that bindings can be specified and generated directly in CMake, similar to how pybind11 works.

Please destroy! Cheers.




