### PR TITLE
Collapse repeated interface blocks after parsing

### DIFF
--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -678,6 +678,22 @@ class LowerCaseConverter(FortranTransformer):
         node.attributes = [a.lower() for a in node.attributes]
         return self.generic_visit(node)
 
+
+class RepeatedInterfaceCollapser(FortranTransformer):
+    """
+    Collapse repeated interfaces with the same name into a single interface
+    """
+
+    def visit_Module(self, node):
+        interface_map = {}
+        for interface in node.interfaces:
+            if interface.name in interface_map:
+                interface_map[interface.name].procedures.extend(interface.procedures)
+            else:
+                interface_map[interface.name] = interface
+        node.interfaces = list(interface_map.values())
+        return self.generic_visit(node)
+
 def strip_type(t):
     """Return type name from type declaration"""
     t = t.replace(' ', '')  # remove blanks

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -44,8 +44,16 @@ import logging
 import string
 import sys
 import os
+import re
 
-from f90wrap.fortran import *       #fixme: remove star import
+from f90wrap.fortran import (Fortran, Root, Program, Module,
+                             Procedure, Subroutine, Function, Interface,
+                             Prototype, Declaration,
+                             Argument, Element, Type,
+                             fix_argument_attributes,
+                             LowerCaseConverter,
+                             RepeatedInterfaceCollapser)
+
 
 log = logging.getLogger(__name__)
 
@@ -1502,8 +1510,7 @@ def read_files(args, doc_plugin_filename=None):
             cline = file.next()
 
     # apply some rules to the parsed tree
-    from f90wrap.fortran import fix_argument_attributes, LowerCaseConverter
-
     root = fix_argument_attributes(root)
     root = LowerCaseConverter().visit(root)
+    root = RepeatedInterfaceCollapser().visit(root)
     return root


### PR DESCRIPTION
Fixes regression introduced in PR #133, and fixes issue libAtoms/quip#264