### PR TITLE
import Binding class included in parser

### DIFF
--- a/examples/errorbinding/Makefile
+++ b/examples/errorbinding/Makefile
@@ -1,0 +1,142 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = ExampleDerivedTypes
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = parameters datatypes
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = datatypes
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so
+
+
+clean:
+	-rm -f ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}*.so \
+	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o ${PYTHON_MODN}.py
+	-rm -rf ${PYTHON_MODN}_pkg
+	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+_${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
+
+
+test: all
+	${PYTHON} tests.py
+	${PYTHON} tests_pkg.py

--- a/examples/errorbinding/README.md
+++ b/examples/errorbinding/README.md
@@ -1,0 +1,22 @@
+Error by absent Binding
+=====================
+
+Minimal example to reproduce error due to absense of import Bindining
+in "parser.py" script. Created from a copy of example derivedtype.
+
+In previous version of f90wrap (version 0.2.2 dos not give this issue)
+I used to write by myself the procedure where class is replaced by
+tpye and in the example derivedtype.
+
+
+To generate the error use the included ```Makefile```:
+
+```
+make
+```
+
+Author
+------
+
+Enrico Facca: <enrico.facca@gmail.com>
+

--- a/examples/errorbinding/datatypes.f90
+++ b/examples/errorbinding/datatypes.f90
@@ -1,0 +1,48 @@
+! ==============================================================================
+module datatypes
+use parameters, only: idp, isp
+implicit none
+private 
+public :: typewithprocedure, constructor_typewithprocedure, info_typewithprocedure
+type :: typewithprocedure
+   REAL(idp) :: a
+   INTEGER(4) :: n
+ contains
+   procedure, public :: init => init_procedure
+   procedure, public :: info => info_procedure
+end type typewithprocedure
+contains
+
+  subroutine init_procedure(this, a, n)
+    class(typewithprocedure), intent(inout) :: this
+    REAL(idp),   intent(in   ) :: a
+    INTEGER(4),  INTENT(in) :: n
+
+    this%a = a
+    this%n = n
+  end subroutine init_procedure
+
+  subroutine info_procedure(this, lun)
+    class(typewithprocedure), intent(inout) :: this
+    INTEGER(4),  INTENT(in) :: lun
+
+    write(lun,*) ' a = ', this%a, 'n = ', this%n
+  end subroutine info_procedure
+
+  subroutine constructor_typewithprocedure(this, a, n)
+    type(typewithprocedure), intent(inout) :: this
+    REAL(idp),   intent(in   ) :: a
+    INTEGER(4),  INTENT(in) :: n
+
+    call this%init(a,n)
+  end subroutine constructor_typewithprocedure
+
+
+  subroutine info_typewithprocedure(this, lun)
+    type(typewithprocedure), intent(inout) :: this
+    INTEGER(4),  INTENT(in) :: lun
+
+    call this%info(lun)
+  end subroutine info_typewithprocedure
+
+end module datatypes

--- a/examples/errorbinding/kind_map
+++ b/examples/errorbinding/kind_map
@@ -1,0 +1,17 @@
+{
+ 'real':     {   '' : 'float',
+                '4' : 'float',
+              'isp' : 'float',
+                '8' : 'double',
+               'dp' : 'double',
+              'idp' : 'double'},
+ 'complex' : {   '' : 'complex_float',
+ 	            '8' : 'complex_double',
+ 	           '16' : 'complex_long_double',
+ 	           'dp' : 'complex_double'},
+ 'integer' : {  '4' : 'int',
+	            '8' : 'long_long',
+	           'dp' : 'long_long' },
+ 'character' : {''  : 'char',
+                '1' : 'char' }
+}

--- a/examples/errorbinding/parameters.f90
+++ b/examples/errorbinding/parameters.f90
@@ -1,0 +1,13 @@
+module parameters
+
+implicit none
+private
+public :: idp, isp
+
+INTEGER, PARAMETER :: idp=kind(1d0) ! double precision, np.float64 equivalent
+INTEGER, PARAMETER :: isp=kind(1e0) ! single precision, np.float32 equivalent
+
+contains
+
+end module parameters
+

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -46,7 +46,7 @@ import sys
 import os
 import re
 
-from f90wrap.fortran import (Fortran, Root, Program, Module,
+from f90wrap.fortran import (Fortran, Binding,Root, Program, Module,
                              Procedure, Subroutine, Function, Interface,
                              Prototype, Declaration,
                              Argument, Element, Type,

--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -46,13 +46,14 @@ import sys
 import os
 import re
 
-from f90wrap.fortran import (Fortran, Binding,Root, Program, Module,
+from f90wrap.fortran import (Fortran, Root, Program, Module,
                              Procedure, Subroutine, Function, Interface,
                              Prototype, Declaration,
                              Argument, Element, Type,
                              fix_argument_attributes,
                              LowerCaseConverter,
-                             RepeatedInterfaceCollapser)
+                             RepeatedInterfaceCollapser,
+                             Binding,)
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Using f90wrap in [this project](https://gitlab.com/enrico_facca/geometry) I noticed that in the parser script the class Binding was not imported. Including this class fixed my issues.
In order to reproduce the error follow the instruction in the README file and create the fortran-python interface with 
```
make f2py_interface_geometry
```