### PR TITLE
Fix for line breaks on empty lines

### DIFF
--- a/f90wrap/codegen.py
+++ b/f90wrap/codegen.py
@@ -123,7 +123,7 @@ class CodeGenerator(object):
                 while tokens:
                     token = tokens.pop(0)
                     current_line = ' '.join(split_lines[-1])
-                    if len(current_line) + len(token) < self.max_length:
+                    if len(current_line) == 0 or len(current_line) + len(token) < self.max_length:
                         split_lines[-1].append(token)
                     else:
                         split_lines[-1].append(self.continuation)


### PR DESCRIPTION
The line-splitting code currently inserts a line continuation on an otherwise empty line if the first token in a line is longer than the maximum allowed length. Python 3.9 does not seem to like this (see #153). This PR hopefully fixes this behaviour. It seems to work on the piece of code that was causing problems in #153 but I have not done much testing beyond that.