### PR TITLE
Improved compatibility with integer(8) as default integer in F90 sources

### DIFF
--- a/examples/default_i8/Makefile
+++ b/examples/default_i8/Makefile
@@ -1,0 +1,137 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+    FLAG_INT = -fdefault-integer-8
+    FPP      = gfortran -E
+    FPP_F90FLAGS = -x f95-cpp-input -fPIC -fdefault-integer-8
+    F90FLAGS = -fPIC -fdefault-integer-8
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+#ifeq ($(F90),ifort)
+#    FLAG_INT = -fdefault-integer-8
+#    FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+#    FPP_F90FLAGS = -x f95-cpp-input -fPIC
+#    F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+#    FCOMP    = intelem # for f2py
+#    LIBS =
+#endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = testmodule
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = test
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = test
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so test
+
+
+clean:
+	-rm -f ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}*.so \
+	 *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o ${PYTHON_MODN}.py
+	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --f90flags='-fdefault-integer-8' --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+test: _${PYTHON_MODN}.so
+	${PYTHON} tests.py
+

--- a/examples/default_i8/kind_map
+++ b/examples/default_i8/kind_map
@@ -1,0 +1,15 @@
+{
+ 'real':     {'': 'float',
+              '8': 'double',
+              'dp': 'double',
+              'idp':'double'},
+ 'complex' : {'': 'complex_float',
+ 	          '8' : 'complex_double',
+ 	          '16': 'complex_long_double',
+ 	          'dp': 'complex_double'},
+ 'integer' : {    ''  : 'long_long',
+                  '4' : 'int',
+	          '8' : 'long_long',
+	          'dp': 'long_long' },
+ 'character' : {'': 'char'}
+}

--- a/examples/default_i8/test.f90
+++ b/examples/default_i8/test.f90
@@ -1,0 +1,30 @@
+module my_module
+implicit none
+
+type mytype
+   integer :: n=0,m=0
+   real(8), allocatable :: y(:,:)
+end type mytype
+  
+contains
+
+subroutine allocit(x,n,m)
+  implicit none
+  integer, intent(in) :: n,m
+  type(mytype), intent(inout) :: x
+  integer i,j
+
+  write(6,*) 'allocit> n,m=',n,m
+
+  x%n = n; x%m = m
+  allocate(x%y(n,m))
+
+  do i = 1, n 
+   do j = 1, m
+    x%y(i,j) = real(i+j)/real(n+m)
+   end do
+  end do
+
+end subroutine allocit
+
+end module my_module

--- a/examples/default_i8/tests.py
+++ b/examples/default_i8/tests.py
@@ -1,0 +1,67 @@
+#  f90wrap: F90 to Python interface generator with derived type support
+#
+#  Copyright James Kermode 2011-2018
+#
+#  This file is part of f90wrap
+#  For the latest version see github.com/jameskermode/f90wrap
+#
+#  f90wrap is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  f90wrap is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
+# 
+#  If you would like to license the source code under different terms,
+#  please contact James Kermode, james.kermode@gmail.com
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 15:19:03 2015
+
+@author: David Verelst
+"""
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import testmodule as lib
+
+
+class TestExample(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def do_array_stuff(self, n=3, m=4):
+
+        print("n,m=",n,m)
+        x = lib.my_module.mytype()
+        lib.my_module.allocit(x,n,m)
+
+        sum = 0.0
+        for k in range(n):
+              for j in range(m):
+                  sum += x.y[k,j]
+        print("sum = %20.10f  .... x.y[%d,%d] = %20.10f \n" % ( sum, n,m,x.y[n-1,m-1] ) )
+
+    def test_basic(self):
+        self.do_array_stuff(1,2)
+
+    def test_normal_array(self):
+        self.do_array_stuff(10,20)
+
+    def test_verybig_array(self):
+        self.do_array_stuff(50,99)
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -448,7 +448,7 @@ end type %(typename)s_rec_ptr_type""" % {'typename': tname})
         else:
             self.write_uses_lines(t)
 
-        self.write('use, intrinsic :: iso_c_binding, only : c_int'
+        self.write('use, intrinsic :: iso_c_binding, only : c_int')
         self.write('implicit none')
         if isinstance(t, ft.Type):
             self.write_type_lines(t.name)

--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -448,23 +448,24 @@ end type %(typename)s_rec_ptr_type""" % {'typename': tname})
         else:
             self.write_uses_lines(t)
 
+        self.write('use, intrinsic :: iso_c_binding, only : c_int'
         self.write('implicit none')
         if isinstance(t, ft.Type):
             self.write_type_lines(t.name)
-            self.write('integer, intent(in) :: this(%d)' % sizeof_fortran_t)
+            self.write('integer(c_int), intent(in) :: this(%d)' % sizeof_fortran_t)
             self.write('type(%s_ptr_type) :: this_ptr' % t.name)
         else:
             self.write('integer, intent(in) :: dummy_this(%d)' % sizeof_fortran_t)
 
-        self.write('integer, intent(out) :: nd')
-        self.write('integer, intent(out) :: dtype')
+        self.write('integer(c_int), intent(out) :: nd')
+        self.write('integer(c_int), intent(out) :: dtype')
         try:
             rank = len(ArrayDimensionConverter.split_dimensions(dims))
             if el.type.startswith('character'):
                 rank += 1
         except ValueError:
             rank = 1
-        self.write('integer, dimension(10), intent(out) :: dshape')
+        self.write('integer(c_int), dimension(10), intent(out) :: dshape')
         self.write('integer*%d, intent(out) :: dloc' % np.dtype('O').itemsize)
         self.write()
         self.write('nd = %d' % rank)


### PR DESCRIPTION
Fixes issue 164.
Arrays in derived types with 2 or more dimensions were before not accessible in python if the Fortran sources where compiled with integer(8) as default integer because these settings broke the f90-C interfaces generated by f90wrap.
This is now avoided by using for integer types from the iso_c_binding module in the generated Fortran routines.