### PR TITLE
Fix issue 172

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND tests
     arrays
     arrays_fixed
     arrays_in_derived_types_issue50
+    class_names
     cylinder
     derivedtypes
     elemental

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,6 +2,7 @@ EXAMPLES = arrayderivedtypes \
 	arrays \
 	arrays_fixed \
 	arrays_in_derived_types_issue50 \
+	class_names \
 	cylinder \
 	derivedtypes \
 	elemental \

--- a/examples/class_names/Makefile
+++ b/examples/class_names/Makefile
@@ -1,0 +1,136 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC       = gcc
+F90      = gfortran
+#F90      = ifort
+#F90      =  /opt/intel/composer_xe_2015.3.187/bin/intel64/ifort
+PYTHON   = python
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+
+ifeq ($(F90),gfortran)
+	FPP      = gfortran -E
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fPIC
+    FCOMP    = gfortran
+    LIBS     =
+endif
+
+ifeq ($(F90),ifort)
+
+	FPP      = gfortran -E # gfortran f90wrap temp files only. not compilation
+	FPP_F90FLAGS = -x f95-cpp-input -fPIC
+	F90FLAGS = -fpscomp logicals -fPIC # use 1 and 0 for True and False
+    FCOMP    = intelem # for f2py
+    LIBS =
+endif
+
+CFLAGS  = -fPIC #     ==> universal for ifort, gfortran, pgi
+
+#=======================================================================
+#=======================================================================
+
+UNAME = $(shell uname)
+
+ifeq (${UNAME}, Darwin)
+  LIBTOOL = libtool -static -o
+else
+  LIBTOOL = ar src
+endif
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = classnames
+# mapping between Fortran and C types
+KIND_MAP = kind_map
+
+#=======================================================================
+#
+#=======================================================================
+
+#VPATH	=
+
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = test
+
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+
+# only used when cleaning up
+LIBSRC_FPP_FILES = $(addsuffix .fpp,${LIBSRC_SOURCES})
+
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = test
+
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+
+# object files
+LIBSRC_WRAP_OBJECTS = $(addsuffix .o,${LIBSRC_WRAP_SOURCES})
+
+# fpp files
+LIBSRC_WRAP_FPP_FILES = $(addsuffix .fpp,${LIBSRC_WRAP_SOURCES})
+
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+
+.SUFFIXES: .f90 .fpp
+
+#=======================================================================
+#
+#=======================================================================
+
+.PHONY: all clean
+
+
+all: _${PYTHON_MODN}.so test
+
+
+clean:
+	-rm -f ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}*.so \
+	 *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o ${PYTHON_MODN}.py
+	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/
+
+
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+
+
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+
+
+.f90.fpp:
+	${FPP} ${FPP_F90FLAGS} $<  -o $@
+
+
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+
+
+_${PYTHON_MODN}.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN} ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} --class-names class_names.json -v
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN} -L. -lsrc f90wrap*.f90
+
+
+test: _${PYTHON_MODN}.so
+	${PYTHON} tests.py
+

--- a/examples/class_names/class_names.json
+++ b/examples/class_names/class_names.json
@@ -1,0 +1,5 @@
+{
+   "module_snake_mod": "ModuleSnake",
+   "array_type": "ArrayType",
+   "ceci_ne_pas_un_chameau": "IAmACamel"
+}

--- a/examples/class_names/kind_map
+++ b/examples/class_names/kind_map
@@ -1,0 +1,14 @@
+{
+ 'real':     {'': 'float',
+              '8': 'double',
+              'dp': 'double',
+              'idp':'double'},
+ 'complex' : {'': 'complex_float',
+ 	          '8' : 'complex_double',
+ 	          '16': 'complex_long_double',
+ 	          'dp': 'complex_double'},
+ 'integer' : {'4': 'int',
+	          '8': 'long_long',
+	          'dp': 'long_long' },
+ 'character' : {'': 'char'}
+}

--- a/examples/class_names/test.f90
+++ b/examples/class_names/test.f90
@@ -1,0 +1,17 @@
+module module_snake_mod
+  type ceci_ne_pas_un_chameau
+     integer :: y
+  end type ceci_ne_pas_un_chameau
+  
+  type array_type
+     type(ceci_ne_pas_un_chameau) :: x(2)
+  end type array_type
+
+  type(array_type), dimension(10), target :: xarr
+  
+contains
+  subroutine recup_point(x)
+    type(array_type) :: x
+    return
+  end subroutine recup_point
+end module module_snake_mod

--- a/examples/class_names/tests.py
+++ b/examples/class_names/tests.py
@@ -1,0 +1,26 @@
+#  f90wrap: F90 to Python interface generator with derived type support
+#
+#  Copyright James Kermode 2011-2018
+#
+#  This file is part of f90wrap
+#  For the latest version see github.com/jameskermode/f90wrap
+#
+#  f90wrap is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  f90wrap is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
+# 
+#  If you would like to license the source code under different terms,
+#  please contact James Kermode, james.kermode@gmail.com
+import classnames
+
+
+

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -726,7 +726,7 @@ return %(el_name)s""" % dct)
                    parent='self',
                    doc=format_doc_string(el),
                    cls_name=cls_name,
-                   cls_mod_name=cls_mod_name + '.')
+                   cls_mod_name=normalise_class_name(cls_mod_name, self.class_names) + '.')
 
         if isinstance(node, ft.Module):
             dct['parent'] = 'f90wrap.runtime.empty_type'

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -726,7 +726,7 @@ return %(el_name)s""" % dct)
                    parent='self',
                    doc=format_doc_string(el),
                    cls_name=cls_name,
-                   cls_mod_name=cls_mod_name.title() + '.')
+                   cls_mod_name=cls_mod_name + '.')
 
         if isinstance(node, ft.Module):
             dct['parent'] = 'f90wrap.runtime.empty_type'


### PR DESCRIPTION
The issue seems to boil down to line 729 of `pywrapgen.py` (construction of a dict of function arguments) which refers to `cls_mod_name.title()`. The proper way of transforming module class name is a  function `normalise_class_name()`.

Closes #172