### PR TITLE
Change global variable name in set_array_

### DIFF
--- a/examples/arrays/library.f90
+++ b/examples/arrays/library.f90
@@ -3,7 +3,9 @@ module library
     use parameters, only: idp, isp
     implicit none
     private
-    public :: do_array_stuff, only_manipulate, return_array
+    public :: do_array_stuff, only_manipulate, return_array, ia, iarray
+    integer(4) :: ia
+    integer(4) :: iarray(3)
 
 contains
 

--- a/examples/arrays/tests.py
+++ b/examples/arrays/tests.py
@@ -33,7 +33,7 @@ import unittest
 
 import numpy as np
 
-import ExampleArray as lib
+import ExampleArray_pkg as lib
 
 
 class TestExample(unittest.TestCase):
@@ -79,6 +79,17 @@ class TestExample(unittest.TestCase):
         ii += 1
         jj += 1
         np.testing.assert_equal(ii*jj + jj, arr)
+
+    def test_set_value(self):
+        lib.library.set_ia(1)
+        ia = lib.library.get_ia()
+        np.testing.assert_equal(ia, 1)
+
+    def test_set_array(self):
+        iarray_ref = np.arange(0, 3, dtype=np.int32)
+        lib.library.set_array_iarray(iarray_ref)
+        iarray = lib.library.get_array_iarray()
+        np.testing.assert_allclose(iarray, iarray_ref)
 
 
 if __name__ == '__main__':

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -736,8 +736,13 @@ return %(el_name)s""" % dct)
         self.write()
         if not isinstance(node, ft.Module) or not self.make_package:
             self.write("@%(el_name)s.setter" % dct)
-        self.write("""def %(el_name_set)s(%(selfcomma)s%(el_name)s):
+        if dct['selfdot'] :
+            self.write("""def %(el_name_set)s(%(selfcomma)s%(el_name)s):
     %(selfdot)s%(el_name)s[...] = %(el_name)s
+""" % dct)
+        else :
+            self.write("""def %(el_name_set)s(%(selfcomma)s%(el_name)s):
+    globals()['%(selfdot)s%(el_name)s'][...] = %(el_name)s
 """ % dct)
         self.write()
 


### PR DESCRIPTION
In `sub_array_*` functions, the global variable has the same name as the input local variable, and sometimes it doesn't work as expected. The global variable is replaced by `globals()`. 

Environment:
  - python: 3.10.6
  - ubuntu: 22.04