### PR TITLE
add copy to FortranDerivedType

### DIFF
--- a/examples/derivedtypes/tests.py
+++ b/examples/derivedtypes/tests.py
@@ -263,6 +263,34 @@ class BaseTests(object):
         self.assertEqual(len(dt.omicron), n)
         self.assertEqual(len(dt.pi), n)
 
+    def test_copy_nested_alloc_arrays(self):
+
+        n = 10
+        dt = self.lib.datatypes.array_nested()
+        self.lib.datatypes.init_array_nested(dt, n)
+
+        dt.xi[0].beta = 1
+        dt.xi[0].delta = 1.0
+
+        dt2 = dt.copy()
+
+        self.assertEqual(dt2.xi[0].beta, 1)
+        self.assertEqual(dt2.xi[0].delta, 1.0)
+
+        dt.xi[0].beta = 2
+        dt.xi[0].delta = 2.0
+
+        self.assertEqual(dt.xi[0].beta, 2)
+        self.assertEqual(dt.xi[0].delta, 2.0)
+
+        self.lib.datatypes.destroy_array_nested(dt)
+
+        def get_xi():
+            return dt.xi[0]
+        self.assertRaises(RuntimeError, get_xi)
+
+        self.assertEqual(dt2.xi[0].beta, 1)
+        self.assertEqual(dt2.xi[0].delta, 1.0)
 
 
 if pkg:

--- a/f90wrap/fortrantype.py
+++ b/f90wrap/fortrantype.py
@@ -78,6 +78,24 @@ class FortranDerivedType(object):
         self._alloc = alloc
         return self
 
+    def __copy__(self):
+        out = FortranDerivedType()
+        for attr in dir(self):
+            if attr.startswith('_') : continue
+            # skip some attributes
+            if attr in ['from_handle', 'copy'] : continue
+            try:
+                value = getattr(self, attr)
+            except Exception :
+                pass
+            else:
+                if hasattr(value, 'copy') : value = value.copy()
+                setattr(out, attr, value)
+        return out
+
+    def copy(self):
+        return self.__copy__()
+
 
 class FortranDerivedTypeArray(object):
     def __init__(self, parent, getfunc, setfunc, lenfunc, doc, arraytype):
@@ -129,3 +147,13 @@ class FortranDerivedTypeArray(object):
         # i += 1 # convert from 0-based (Python) to 1-based indices (Fortran)
         # YANN: Same issue
         self.setfunc(parent._handle, i + 1, value._handle)
+
+    def __copy__(self):
+        out = []
+        for item in self :
+            if hasattr(item, 'copy') : item = item.copy()
+            out.append(item)
+        return out
+
+    def copy(self):
+        return self.__copy__()


### PR DESCRIPTION
Add `copy` to class `FortranDerivedType` and `FortranDerivedTypeArray`. The copy will only keep the values and disconnect to the Fortran code. The copy of `FortranDerivedTypeArray` will return a list of copied `FortranDerivedType`.