### PR TITLE
support type-bound procedures

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -20,7 +20,8 @@ EXAMPLES = arrayderivedtypes \
 	subroutine_contains_issue101 \
 	type_bn \
 	docstring \
-	type_check
+	type_check \
+	derivedtypes_procedure
 
 PYTHON = python
 

--- a/examples/derivedtypes_procedure/Makefile
+++ b/examples/derivedtypes_procedure/Makefile
@@ -1,0 +1,23 @@
+FC = gfortran
+CFLAGS = -fPIC
+PYTHON = python
+
+all: test
+
+%.o : %.f90
+	${FC} ${CFLAGS} -c $< -o $@
+
+library.o: library.f90
+
+tests.py: library.o
+	python -m f90wrap -m library library.f90 -v
+	python -m f90wrap --f2py-f90wrap -c -m _library f90wrap_*.f90 library.o
+
+test: tests.py
+	$(PYTHON) tests.py
+
+clean:
+	-rm -f *.o f90wrap*.f90 *.so *.mod *.pyc
+	-rm -rf __pycache__
+	-rm -f library.py
+	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/

--- a/examples/derivedtypes_procedure/library.f90
+++ b/examples/derivedtypes_procedure/library.f90
@@ -1,0 +1,83 @@
+module test
+  implicit none
+
+  private
+  public :: atype, btype
+  public :: create, asum
+  public :: asum_class
+
+  type :: atype
+     integer, allocatable        :: array(:)
+  contains
+     procedure                   :: p_create => create_class
+     procedure                   :: p_asum => asum_class
+     procedure                   :: p_asum_2 => asum_class
+     procedure                   :: asum_class
+     procedure                   :: p_reset => assignment_value
+     generic                     :: assignment(=) => p_reset
+  end type atype
+
+  type :: btype
+     integer                     :: array(3)
+  contains
+     procedure                   :: p_asum => bsum_class
+  end type btype
+
+contains
+
+   subroutine create(self, n)
+      implicit none
+      type(atype),intent(inout)  :: self
+      integer                    :: n
+      !
+      if (allocated(self%array)) deallocate(self%array)
+      allocate(self%array(n))
+      !
+   end subroutine
+
+   subroutine create_class(self, n)
+      implicit none
+      class(atype),intent(inout) :: self
+      integer                    :: n
+      !
+      call create(self, n)
+      !
+   end subroutine
+
+   function asum(self)
+      implicit none
+      type(atype),intent(in)     :: self
+      real                       :: asum
+      !
+      asum = sum(self%array)
+      !
+   end function
+
+   function asum_class(self)
+      implicit none
+      class(atype),intent(in)    :: self
+      real                       :: asum_class
+      !
+      asum_class = asum(self)
+      !
+   end function
+
+   subroutine assignment_value(self, value)
+      implicit none
+      class(atype),intent(inout) :: self
+      integer,intent(in)         :: value
+      !
+      self%array(:) = value
+      !
+   end subroutine
+
+   function bsum_class(self)
+      implicit none
+      class(btype),intent(in)    :: self
+      real                       :: bsum_class
+      !
+      bsum_class = sum(self%array)
+      !
+   end function
+
+end module

--- a/examples/derivedtypes_procedure/tests.py
+++ b/examples/derivedtypes_procedure/tests.py
@@ -1,0 +1,63 @@
+import unittest
+import library
+lib = library.test
+
+
+class TestExample(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_create(self):
+        data = lib.atype()
+        lib.create(data, 10)
+        self.assertEqual(len(data.array), 10)
+
+    def test_type_create(self):
+        data = lib.atype()
+        data.p_create(10)
+        self.assertEqual(len(data.array), 10)
+
+    def test_asum(self):
+        data = lib.atype()
+        lib.create(data, 10)
+        data.array[:] = 1
+        a = lib.asum(data)
+        self.assertEqual(a, 10)
+        a = lib.asum_class(data)
+        self.assertEqual(a, 10)
+
+    def test_type_asum(self):
+        data = lib.atype()
+        data.p_create(10)
+        data.array[:] = 1
+        a = data.p_asum()
+        self.assertEqual(a, 10)
+        a2 = data.asum_class()
+        self.assertEqual(a2, 10)
+        a3 = data.p_asum_2()
+        self.assertEqual(a3, 10)
+
+    def test_type_asum_b(self):
+        data = lib.atype()
+        data.p_create(10)
+        data.array[:] = 1
+        a = data.p_asum()
+        self.assertEqual(a, 10)
+        data2 = lib.btype()
+        data2.array[:] = 1
+        b = data2.p_asum()
+        self.assertEqual(b, 3)
+
+    def test_type_assignment(self):
+        data = lib.atype()
+        data.p_create(10)
+        data.array[:] = 1
+        data.p_reset(2)
+        a = data.p_asum()
+        self.assertEqual(a, 20)
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -402,7 +402,8 @@ except ValueError:
             self.write_destructor(node)
         else:
             dct = dict(func_name=node.name,
-                       method_name=hasattr(node, 'method_name') and node.method_name or node.name,
+                       method_name= (hasattr(node, 'binding_name') and node.binding_name) or
+                           (hasattr(node, 'method_name') and node.method_name) or node.name,
                        prefix=self.prefix,
                        mod_name=self.f90_mod_name,
                        py_arg_names=', '.join([arg.py_name + py_arg_value(arg) for arg in node.arguments]),


### PR DESCRIPTION
Improve and update the support for type-bound procedures, allowing for multiple types of procedures. Additionally, module procedures also can be used as regular procedures.