### PR TITLE
numpy 1.24 support

### DIFF
--- a/examples/derivedtypes/tests.py
+++ b/examples/derivedtypes/tests.py
@@ -136,7 +136,7 @@ class BaseTests(object):
         self.assert_(isinstance(dt, self.lib.datatypes.fixed_shape_arrays))
 
         self.assertEqual(dt.eta.dtype, np.int32)
-        eta = np.ones((10,4), dtype=np.int)
+        eta = np.ones((10,4), dtype=np.int32)
         np.testing.assert_array_equal(dt.eta, eta*10)
 
         # FIXME: Fails because dt.theta is not float32 (single precision)

--- a/examples/type_check/type_check_test.py
+++ b/examples/type_check/type_check_test.py
@@ -76,7 +76,7 @@ class TestTypeCheck(unittest.TestCase):
             m_circle.is_circle(1., 1.)
 
     def test_no_suitable_version_2(self):
-        out = np.array([-1], dtype=np.complex)
+        out = np.array([-1], dtype=np.complex128)
 
         with self.assertRaises(TypeError):
             m_circle.write_array(out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Fortran to Python interface generator with derived type support"
 authors = [{name = "James Kermode", email = "james.kermode@gmail.com"}]
 python-requires = ">=3.6"
 urls = {Homepage = "https://github.com/jameskermode/f90wrap"}
-dependencies = ["numpy>=1.13,<1.24"]
+dependencies = ["numpy>=1.13"]
 dynamic = ["version"]
 
 [project.readme]


### PR DESCRIPTION
- Update deprecated dtype alias in examples: np.int -> np.int32; np.complex -> np.complex128
- Update f2py patches
- Remove numpy version upper bound