### PR TITLE
Revert windows runner change

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]
-        - [macos-latest, macosx, x86_64]
-        - [windows-latest, win, AMD64]
+        - [macos-12, macosx, x86_64]
+        - [windows-2019, win, AMD64]
 
         python: ["cp38", "cp39", "cp310", "cp311"]
       fail-fast: false


### PR DESCRIPTION
Go back to windows-2019 rather than windows-latest, since -latest now links to windows-server-2022, which breaks the wheel building in CI.

Example failure: 

https://github.com/jameskermode/f90wrap/actions/runs/4939251190/jobs/8829813446#step:4:185
