### PR TITLE
support relative import for the package

### DIFF
--- a/examples/arrays/Makefile
+++ b/examples/arrays/Makefile
@@ -107,7 +107,7 @@ all: _${PYTHON_MODN}.so _${PYTHON_MODN}_pkg.so test
 clean:
 	-rm -f ${LIBSRC_OBJECTS} ${LIBSRC_FPP_FILES} libsrc.a _${PYTHON_MODN}*.so \
 	_${PYTHON_MODN}_pkg.so *.mod *.fpp f90wrap*.f90 f90wrap*.o *.o ${PYTHON_MODN}.py
-	-rm -rf ${PYTHON_MODN}_pkg/
+	-rm -rf ${PYTHON_MODN}_*/
 	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/
 
 
@@ -136,7 +136,14 @@ _${PYTHON_MODN}_pkg.so: libsrc.a ${LIBSRC_FPP_FILES}
 	f90wrap -m ${PYTHON_MODN}_pkg ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P
 	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_pkg -L. -lsrc f90wrap*.f90
 
+_${PYTHON_MODN}_relative.so: libsrc.a ${LIBSRC_FPP_FILES}
+	f90wrap -m ${PYTHON_MODN}_relative ${LIBSRC_WRAP_FPP_FILES} -k ${KIND_MAP} -v -P --relative
+	f2py-f90wrap --fcompiler=$(FCOMP) --build-dir . -c -m _${PYTHON_MODN}_relative -L. -lsrc f90wrap*.f90
+	mkdir ${PYTHON_MODN}_top
+	mv ${PYTHON_MODN}_relative/ _${PYTHON_MODN}_relative.*so ${PYTHON_MODN}_top/
+	touch ${PYTHON_MODN}_top/__init__.py
 
-test: _${PYTHON_MODN}_pkg.so _${PYTHON_MODN}.so 
+
+test: _${PYTHON_MODN}_pkg.so _${PYTHON_MODN}.so  _${PYTHON_MODN}_relative.so 
 	${PYTHON} tests.py
 

--- a/examples/arrays/tests.py
+++ b/examples/arrays/tests.py
@@ -33,10 +33,10 @@ import unittest
 
 import numpy as np
 
-import ExampleArray_pkg as lib
-
 
 class TestExample(unittest.TestCase):
+
+    import ExampleArray_pkg as lib
 
     def setUp(self):
         pass
@@ -47,7 +47,7 @@ class TestExample(unittest.TestCase):
         br = np.zeros((ndata,), order='F')
         co = np.zeros((4, ndata), order='F')
 
-        lib.library.do_array_stuff(n=ndata, x=x, y=y, br=br, co=co)
+        self.lib.library.do_array_stuff(n=ndata, x=x, y=y, br=br, co=co)
 
         for k in range(4):
             np.testing.assert_allclose(x*y + x, co[k,:])
@@ -66,32 +66,34 @@ class TestExample(unittest.TestCase):
         br = np.zeros((n,), order='F')
         co = np.zeros((4, n), order='F')
 
-        lib.library.do_array_stuff(n=n, x=x, y=y, br=br, co=co)
-        lib.library.only_manipulate(n=n, array=co)
+        self.lib.library.do_array_stuff(n=n, x=x, y=y, br=br, co=co)
+        self.lib.library.only_manipulate(n=n, array=co)
         for k in range(4):
             np.testing.assert_allclose((x*y + x)**2, co[k,:])
 
     def test_return_array(self):
         m, n = 10, 4
         arr = np.ndarray((m,n), order='F', dtype=np.int32)
-        lib.library.return_array(m, n, arr)
+        self.lib.library.return_array(m, n, arr)
         ii, jj = np.mgrid[0:m,0:n]
         ii += 1
         jj += 1
         np.testing.assert_equal(ii*jj + jj, arr)
 
     def test_set_value(self):
-        lib.library.set_ia(1)
-        ia = lib.library.get_ia()
+        self.lib.library.set_ia(1)
+        ia = self.lib.library.get_ia()
         np.testing.assert_equal(ia, 1)
 
     def test_set_array(self):
         iarray_ref = np.arange(0, 3, dtype=np.int32)
-        lib.library.set_array_iarray(iarray_ref)
-        iarray = lib.library.get_array_iarray()
+        self.lib.library.set_array_iarray(iarray_ref)
+        iarray = self.lib.library.get_array_iarray()
         np.testing.assert_allclose(iarray, iarray_ref)
+
+class TestExampleRelative(TestExample):
+    import ExampleArray_top.ExampleArray_relative as lib
 
 
 if __name__ == '__main__':
-
     unittest.main()

--- a/f90wrap/scripts/main.py
+++ b/f90wrap/scripts/main.py
@@ -160,6 +160,8 @@ USAGE
                                                           "Default: 120")
         parser.add_argument('--type-check', action='store_true', default=False,
                             help="Check for type/shape matching of Python argument with the wrapped Fortran subroutine")
+        parser.add_argument('--relative', action='store_true', default=False,
+                            help="Using relative import instead of package name in the package")
 
         args = parser.parse_args()
 
@@ -387,7 +389,9 @@ USAGE
                                       py_mod_names=py_mod_names,
                                       class_names=class_names,
                                       max_length=py_max_line_length,
-                                      type_check=type_check).visit(py_tree)
+                                      type_check=type_check,
+                                      relative = relative,
+                                      ).visit(py_tree)
         fwrap.F90WrapperGenerator(prefix, fsize, string_lengths,
                                   abort_func, kind_map, types, default_to_inout,
                                   max_length=f90_max_line_length).visit(f90_tree)


### PR DESCRIPTION
Add `--relative` to f90wrap to change the absolute import to the relative import in the package. This can be used to create many sub-packages in one big package.