### PR TITLE
Optional out string

### DIFF
--- a/examples/optional_string/Makefile
+++ b/examples/optional_string/Makefile
@@ -1,0 +1,38 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC          = gcc
+F90         = gfortran
+PYTHON      = python
+CFLAGS      = -fPIC
+F90FLAGS    = -fPIC
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v --type-check
+F2PYFLAGS   = --build-dir build
+F90WRAP     = f90wrap
+F2PY        = f2py-f90wrap
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+main.o: ${F90_SRC}
+	${F90} ${F90FLAGS} -c $< -o $@
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+f2py: ${F90WRAP_SRC}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
+
+test: f2py
+	${PYTHON} test.py

--- a/examples/optional_string/main.f90
+++ b/examples/optional_string/main.f90
@@ -1,0 +1,50 @@
+
+module m_string_test
+  implicit none
+  private
+  public :: string_in
+  public :: string_to_string
+  public :: string_to_string_array
+  public :: string_out
+  public :: string_out_optional
+  public :: string_out_optional_array
+
+contains
+
+  subroutine string_in(input)
+    character(len=*), intent(in) :: input
+  end subroutine
+
+  subroutine string_to_string(input,output)
+    character(len=*), intent(in)  :: input
+    character(len=*), intent(out) :: output
+    output=input
+  end subroutine string_to_string
+
+  subroutine string_to_string_array(input,output)
+    character(len=*), intent(in) :: input(:)
+    character(len=*), intent(out) :: output(:)
+    output=input
+  end subroutine string_to_string_array
+
+  subroutine string_out(output)
+    character(len=13), intent(out) :: output
+    output = "output string"
+  end subroutine
+
+  subroutine string_out_optional(output)
+    character(len=13), optional, intent(out) :: output
+    if (present(output)) then
+      output = "output string"
+    endif
+  end subroutine
+
+  subroutine string_out_optional_array(output)
+    character(len=13), optional, intent(out) :: output(:)
+    if (present(output)) then
+      output = "output string"
+    endif
+  end subroutine
+
+end module m_string_test
+

--- a/examples/optional_string/test.py
+++ b/examples/optional_string/test.py
@@ -1,0 +1,57 @@
+import unittest
+import numpy as np
+from packaging import version
+
+from pywrapper import m_string_test
+
+class TestTypeCheck(unittest.TestCase):
+
+    def test_string_in_1(self):
+        m_string_test.string_in('yo')
+
+    def test_string_in_2(self):
+        m_string_test.string_in(np.unicode_('yo'))
+
+    def test_string_in_3(self):
+        m_string_test.string_in(np.string_('yo'))
+
+    def test_string_to_string(self):
+        in_string = b'yo'
+        out_string = m_string_test.string_to_string(in_string)
+        self.assertEqual(in_string, out_string)
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
+    def test_string_to_string_array(self):
+        in_string = np.array(['first ', 'second'], dtype='S6')
+        out_string = np.array([' '*6, ' '*6], dtype='S6')
+        m_string_test.string_to_string_array(in_string, out_string)
+        for i in range(in_string.size):
+            self.assertEqual(in_string[i], out_string[i])
+
+    def test_string_out(self):
+        out_string = m_string_test.string_out()
+        self.assertEqual(out_string, b"output string")
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.23.5") , "This test is known to fail on numpy version older than 1.23.5")
+    def test_string_out_optional(self):
+        out_string = np.array(' '*13, dtype='S13')
+        m_string_test.string_out_optional(out_string)
+        self.assertEqual(out_string, np.array("output string", dtype='S13'))
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.26.3") , "Bug solved in https://github.com/numpy/numpy/pull/24791")
+    def test_string_out_optional_2(self):
+        m_string_test.string_out_optional()
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
+    def test_string_out_optional_array(self):
+        out_string_array = np.array([' '*13, ' '*13], dtype='S13')
+        m_string_test.string_out_optional_array(out_string_array)
+        for out_string in out_string_array:
+            self.assertEqual(out_string, np.array("output string", dtype='S13'))
+
+    def test_string_out_optional_array_2(self):
+        m_string_test.string_out_optional_array()
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/f90wrap/scripts/f2py_f90wrap.py
+++ b/f90wrap/scripts/f2py_f90wrap.py
@@ -19,7 +19,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with f90wrap. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 #  If you would like to license the source code under different terms,
 #  please contact James Kermode, james.kermode@gmail.com
 
@@ -30,7 +30,7 @@ is generated. We make several changes to f2py:
   1. Allow the Fortran :c:func:`present` function to work correctly with optional arguments.
      If an argument to an f2py wrapped function is optional and is not given, replace it
      with ``NULL``.
-     
+
   2. Allow Fortran routines to raise a :exc:`RuntimeError` exception
      with a message by calling an external function
      :c:func:`f90wrap_abort`. This is implemented using a
@@ -166,48 +166,48 @@ def main():
         numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(5, {isoptional: '}'})
 
         del numpy.f2py.rules.arg_rules[33]['frompyobj'][6]
-        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(6, {l_not(isoptional): """\
-        \tif (capi_#varname#_tmp == NULL) {
-        \t\tif (!PyErr_Occurred())
-        \t\t\tPyErr_SetString(#modulename#_error,\"failed in converting #nth# `#varname#\' of #pyname# to C/Fortran array\" );
-        \t} else {
-        \t\t#varname# = (#ctype# *)(capi_#varname#_tmp->data);
-        """})
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(6, {l_not(isoptional): \
+        "\n\t\tif (capi_#varname#_tmp == NULL) {"
+        "\n\t\t\tif (!PyErr_Occurred())"
+        "\n\t\t\t\tPyErr_SetString(#modulename#_error,\"failed in converting #nth# `#varname#\' of #pyname# to C/Fortran array\" );"
+        "\n\t\t} else {"
+        "\n\t\t\t#varname# = (#ctype# *)(capi_#varname#_tmp->data);"
+        })
 
-        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(7, {isoptional:"""\
-        \tif (#varname#_capi != Py_None && capi_#varname#_tmp == NULL) {
-        \t\tif (!PyErr_Occurred())
-        \t\t\tPyErr_SetString(#modulename#_error,\"failed in converting #nth# `#varname#\' of #pyname# to C/Fortran array\" );
-        \t} else {
-        \t\tif (#varname#_capi != Py_None) #varname# = (#ctype# *)(capi_#varname#_tmp->data);
-        """})
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(7, {isoptional:\
+        "\n\t\tif (#varname#_capi != Py_None && capi_#varname#_tmp == NULL) {"
+        "\n\t\t\tif (!PyErr_Occurred())"
+        "\n\t\t\t\tPyErr_SetString(#modulename#_error,\"failed in converting #nth# `#varname#\' of #pyname# to C/Fortran array\" );"
+        "\n\t\t} else {"
+        "\n\t\t\tif (#varname#_capi != Py_None) #varname# = (#ctype# *)(capi_#varname#_tmp->data);"
+        })
 
     else:
-        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(3, {isoptional: 'if (#varname#_capi != Py_None) {'})
-        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(6, {isoptional: '}'})
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(3, {isoptional: '\tif (#varname#_capi != Py_None) {'})
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(6, {isoptional: '\t}'})
 
         del numpy.f2py.rules.arg_rules[33]['frompyobj'][7]
-        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(7, {l_not(isoptional): """\
-        \tif (capi_#varname#_as_array == NULL) {
-        \t\tPyObject* capi_err = PyErr_Occurred();
-        \t\tif (capi_err == NULL) {
-        \t\t\tcapi_err = #modulename#_error;
-        \t\t\tPyErr_SetString(capi_err, capi_errmess);
-        \t\t}
-        \t} else {
-        \t\t#varname# = (#ctype# *)(PyArray_DATA(capi_#varname#_as_array));
-        """})
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(7, {l_not(isoptional):\
+        "\n\t\tif (capi_#varname#_as_array == NULL) {"
+        "\n\t\t\tPyObject* capi_err = PyErr_Occurred();"
+        "\n\t\t\tif (capi_err == NULL) {"
+        "\n\t\t\t\tcapi_err = #modulename#_error;"
+        "\n\t\t\t\tPyErr_SetString(capi_err, capi_errmess);"
+        "\n\t\t\t}"
+        "\n\t\t} else {"
+        "\n\t\t\t#varname# = (#ctype# *)(PyArray_DATA(capi_#varname#_as_array));"
+        })
 
-        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(9, {isoptional:"""\
-        \tif (#varname#_capi != Py_None && capi_#varname#_as_array == NULL) {
-        \t\tPyObject* capi_err = PyErr_Occurred();
-        \t\tif (capi_err == NULL) {
-        \t\t\tcapi_err = #modulename#_error;
-        \t\t\tPyErr_SetString(capi_err, capi_errmess);
-        \t\t}
-        \t} else {
-        \t\tif (#varname#_capi != Py_None) #varname# = (#ctype# *)(PyArray_DATA(capi_#varname#_as_array));
-        """})
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(9, {isoptional:\
+        "\n\t\tif (#varname#_capi != Py_None && capi_#varname#_as_array == NULL) {"
+        "\n\t\t\tPyObject* capi_err = PyErr_Occurred();"
+        "\n\t\t\tif (capi_err == NULL) {"
+        "\n\t\t\t\tcapi_err = #modulename#_error;"
+        "\n\t\t\t\tPyErr_SetString(capi_err, capi_errmess);"
+        "\n\t\t\t}"
+        "\n\t\t} else {"
+        "\n\t\t\tif (#varname#_capi != Py_None) #varname# = (#ctype# *)(PyArray_DATA(capi_#varname#_as_array));"
+        })
 
     # now call the main function
     print('\n!! f90wrap patched version of f2py - James Kermode <james.kermode@gmail.com> !!\n')

--- a/f90wrap/scripts/f2py_f90wrap.py
+++ b/f90wrap/scripts/f2py_f90wrap.py
@@ -198,6 +198,11 @@ def main():
         "\n\t\t\t#varname# = (#ctype# *)(PyArray_DATA(capi_#varname#_as_array));"
         })
 
+        del numpy.f2py.rules.arg_rules[33]['frompyobj'][8]
+        numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(8, {isstringarray:\
+        "\t\tif (#varname#_capi != Py_None) slen(#varname#) = f2py_itemsize(#varname#);"
+        })
+
         numpy.f2py.rules.arg_rules[33]['frompyobj'].insert(9, {isoptional:\
         "\n\t\tif (#varname#_capi != Py_None && capi_#varname#_as_array == NULL) {"
         "\n\t\t\tPyObject* capi_err = PyErr_Occurred();"


### PR DESCRIPTION
Calling a wrapped routine with an optional string array produces a segfault with numpy version >= 1.24.0 when called without the argument.
I belive the problems is that the C generated code trys to acces data from Py_None object.
This PR adds a check in the C generated code from f2py_f90wrap.py script.
It also add some related tests on various way to manipulate strings.
