### PR TITLE
Run optional_string tests from examples Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,7 +21,8 @@ EXAMPLES = arrayderivedtypes \
 	type_bn \
 	docstring \
 	type_check \
-	derivedtypes_procedure
+	derivedtypes_procedure \
+	optional_string
 
 PYTHON = python
 

--- a/examples/optional_string/test.py
+++ b/examples/optional_string/test.py
@@ -16,9 +16,9 @@ class TestTypeCheck(unittest.TestCase):
         m_string_test.string_in(np.string_('yo'))
 
     def test_string_to_string(self):
-        in_string = b'yo'
+        in_string = 'yo'
         out_string = m_string_test.string_to_string(in_string)
-        self.assertEqual(in_string, out_string)
+        self.assertEqual(in_string, out_string.decode("utf-8").strip())
 
     @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
     def test_string_to_string_array(self):
@@ -30,7 +30,7 @@ class TestTypeCheck(unittest.TestCase):
 
     def test_string_out(self):
         out_string = m_string_test.string_out()
-        self.assertEqual(out_string, b"output string")
+        self.assertEqual(out_string.decode("utf-8").strip(), "output string")
 
     @unittest.skipIf(version.parse(np.version.version) < version.parse("1.23.5") , "This test is known to fail on numpy version older than 1.23.5")
     def test_string_out_optional(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Fortran to Python interface generator with derived type support"
 authors = [{name = "James Kermode", email = "james.kermode@gmail.com"}]
 python-requires = ">=3.6"
 urls = {Homepage = "https://github.com/jameskermode/f90wrap"}
-dependencies = ["numpy>=1.13"]
+dependencies = ["numpy>=1.13", "packaging"]
 dynamic = ["version"]
 
 [project.readme]


### PR DESCRIPTION
Sorry, I forgot to add the string tests to the examples makefile. Completes #209

**Edit:** Tests actually needs the `packaging` package to skip tests that are known to fail with older versions of numpy. Is this a problem?