### PR TITLE
Use macos-14 to support arm64

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -27,24 +27,29 @@ jobs:
         - [ubuntu-latest, manylinux, x86_64]
         - [macos-12, macosx, x86_64]
         - [windows-2019, win, AMD64]
+        - [macos-14, macosx, arm64]
 
-        python: ["cp38", "cp39", "cp310", "cp311"]
+        python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        exclude:
+        - buildplat: [macos-14, macosx, arm64]
+          python: "cp38"
+
       fail-fast: false
 
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
@@ -59,13 +64,13 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 15
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
 
       - name: Release wheels
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,7 +29,7 @@ jobs:
         - [windows-2019, win, AMD64]
         - [macos-14, macosx, arm64]
 
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        python: ["cp38", "cp39", "cp310", "cp311"]
         exclude:
         - buildplat: [macos-14, macosx, arm64]
           python: "cp38"


### PR DESCRIPTION
Using the new GitHub Actions Macos runner `macos-14` to build the `macosx-arm64` wheels.