### PR TITLE
FIX: Long subroutine name

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -22,7 +22,8 @@ EXAMPLES = arrayderivedtypes \
 	docstring \
 	type_check \
 	derivedtypes_procedure \
-	optional_string
+	optional_string \
+	long_subroutine_name
 
 PYTHON = python
 

--- a/examples/long_subroutine_name/Makefile
+++ b/examples/long_subroutine_name/Makefile
@@ -1,0 +1,38 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC          = gcc
+F90         = gfortran
+PYTHON      = python
+CFLAGS      = -fPIC
+F90FLAGS    = -fPIC
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v --type-check
+F2PYFLAGS   = --build-dir build
+F90WRAP     = f90wrap
+F2PY        = f2py-f90wrap
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+main.o: ${F90_SRC}
+	${F90} ${F90FLAGS} -c $< -o $@
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+f2py: ${F90WRAP_SRC}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
+
+test: f2py
+	${PYTHON} test.py

--- a/examples/long_subroutine_name/Makefile.meson
+++ b/examples/long_subroutine_name/Makefile.meson
@@ -1,0 +1,6 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+
+test: build
+	$(PYTHON) test.py

--- a/examples/long_subroutine_name/main.f90
+++ b/examples/long_subroutine_name/main.f90
@@ -1,0 +1,25 @@
+module m_long_subroutine_name
+
+    implicit none
+
+    integer :: m_long_subroutine_name_integer
+
+    type m_long_subroutine_name_type
+
+        integer :: m_long_subroutine_name_type_integer
+        integer, dimension(10) :: m_long_subroutine_name_type_integer_array
+
+    end type m_long_subroutine_name_type
+
+    type m_long_subroutine_name_type_2
+
+        type(m_long_subroutine_name_type), dimension(10) :: m_long_subroutine_name_type_2_type_array
+
+    end type m_long_subroutine_name_type_2
+
+contains
+
+    subroutine m_long_subroutine_name_subroutine()
+    end subroutine m_long_subroutine_name_subroutine
+
+end module m_long_subroutine_name

--- a/examples/long_subroutine_name/test.py
+++ b/examples/long_subroutine_name/test.py
@@ -1,0 +1,23 @@
+import unittest
+
+from pywrapper import m_long_subroutine_name
+
+class TestLongSubroutineName(unittest.TestCase):
+
+    def test_long_subroutine_name(self):
+
+        m_long_subroutine_name.m_long_subroutine_name_integer = 42
+
+        typ = m_long_subroutine_name.m_long_subroutine_name_type()
+        typ.m_long_subroutine_name_type_name_integer = 42
+        typ.m_long_subroutine_name_type_name_integer_array = 42
+
+        typ2 = m_long_subroutine_name.m_long_subroutine_name_type_2()
+        typ2.m_long_subroutine_name_type_2_type_array[0].m_long_subroutine_name_type_integer = 42
+        typ2.m_long_subroutine_name_type_2_type_array[0].m_long_subroutine_name_type_integer_array = 42
+        
+        m_long_subroutine_name.m_long_subroutine_name_subroutine()
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -399,6 +399,7 @@ end type %(typename)s_rec_ptr_type""" % {'typename': tname})
         arg_names = '(' + ', '.join([arg.name for arg in node.arguments]) + ')' if node.arguments else ''
         if node.mod_name is not None:
             sub_name = self.prefix + node.mod_name + '__' + node.name
+        sub_name = shorten_long_name(sub_name)
         self.write("subroutine %s%s" % (sub_name, arg_names))
         self.indent()
         self.write_uses_lines(node)


### PR DESCRIPTION
Since PR #215, the name of the module is included in the name of subroutines. As a result, the character limit for a subroutine name is quickly reached. Taking a look at the pull requests, I realised that this problem had already been encountered and solved with the `shorten_long_name` function (PR #178). I took the liberty of applying the same correction to the subroutine names.

When I added the tests, I also realised that this fix was missing for scalar setter.