### PR TITLE
MAINT: numpy 2.0 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ please contact James Kermode <james.kermode@gmail.com>
 Dependencies
 ------------
 
- 1.  [Python](http://www.python.org) 3.7+ (Python 2.7 no longer supported)
+ 1.  [Python](http://www.python.org) 3.8+ (Python 2.7 no longer supported)
  2.  Recent version of [numpy](http://www.numpy.org) which includes `f2py`
  3.  Fortran compiler - tested with `gfortran` 4.6+ and recent `ifort` 12+
 

--- a/examples/optional_string/test.py
+++ b/examples/optional_string/test.py
@@ -10,10 +10,10 @@ class TestTypeCheck(unittest.TestCase):
         m_string_test.string_in('yo')
 
     def test_string_in_2(self):
-        m_string_test.string_in(np.unicode_('yo'))
+        m_string_test.string_in(np.str_('yo'))
 
     def test_string_in_3(self):
-        m_string_test.string_in(np.string_('yo'))
+        m_string_test.string_in(np.bytes_('yo'))
 
     def test_string_to_string(self):
         in_string = 'yo'

--- a/f90wrap/scripts/f2py_f90wrap.py
+++ b/f90wrap/scripts/f2py_f90wrap.py
@@ -72,7 +72,7 @@ def main():
     if(sys.platform == 'win32'):
        includes_inject = includes_inject + "#include <signal.h> // fix https://github.com/jameskermode/f90wrap/issues/73 \n#include <setjmpex.h> // fix https://github.com/jameskermode/f90wrap/issues/96\n"
     else:
-       includes_inject = includes_inject + "#include <setjmp.h>\n"
+       includes_inject = includes_inject + "#include <signal.h>\n#include <setjmp.h>\n"
 
     includes_inject = includes_inject + """
     #define ABORT_BUFFER_SIZE 1024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,17 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["meson-python>=0.12.0", "oldest-supported-numpy"]
+requires = [
+    "meson-python>=0.12.0",
+    "oldest-supported-numpy; python_version=='3.8'",
+    "numpy>=2.0.0; python_version>='3.9'",
+]
 build-backend = 'mesonpy'
 
 [project]
 name = "f90wrap"
 description = "Fortran to Python interface generator with derived type support"
 authors = [{name = "James Kermode", email = "james.kermode@gmail.com"}]
-python-requires = ">=3.6"
+python-requires = ">=3.8"
 urls = {Homepage = "https://github.com/jameskermode/f90wrap"}
 dependencies = ["numpy>=1.13", "packaging"]
 dynamic = ["version"]


### PR DESCRIPTION
Hello,
A pull request to support numpy 2.0

[numpy-2-0-python-api-removals](https://numpy.org/doc/stable/release/2.0.0-notes.html#numpy-2-0-python-api-removals)
- Alias ``np.string_`` has been removed. Use ``np.bytes_`` instead.
- Alias ``np.unicode_`` has been removed. Use ``np.str_`` instead.

[numpy-2-0-c-api-removals](https://numpy.org/doc/stable/release/2.0.0-notes.html#numpy-2-0-c-api-removals)
- ``npy_interrupt.h`` and the corresponding macros like ``NPY_SIGINT_ON`` have been removed.
Need to include ``<signal.h>`` to  avoid ``error: 'SIGINT' undeclared (first use in this function)``

I am not sure if the ``python-package.yml`` workflow is still useful since the same tests are run inside ``build-wheels.yml``