### PR TITLE
Type check

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND tests
     type_bn
     kind_map_default
     docstring
+    return_array
 )
 
 foreach(test ${tests})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND tests
     kind_map_default
     docstring
     return_array
+    intent_out_size
 )
 
 foreach(test ${tests})
@@ -38,5 +39,3 @@ foreach(test ${tests})
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/${test}"
     )
 endforeach()
-
-

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND tests
     return_array
     intent_out_size
     string_array_input_f2py
+    type_check
 )
 
 foreach(test ${tests})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND tests
     subroutine_contains_issue101
     type_bn
     kind_map_default
+    docstring
 )
 
 foreach(test ${tests})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND tests
     intent_out_size
     string_array_input_f2py
     type_check
+    optional_string
 )
 
 foreach(test ${tests})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND tests
     docstring
     return_array
     intent_out_size
+    string_array_input_f2py
 )
 
 foreach(test ${tests})

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -24,6 +24,7 @@ EXAMPLES = arrayderivedtypes \
 	type_check \
 	derivedtypes_procedure \
 	return_array \
+	string_array_input_f2py \
 	optional_string \
 	long_subroutine_name \
 	kind_map_default \

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -23,6 +23,7 @@ EXAMPLES = arrayderivedtypes \
 	docstring \
 	type_check \
 	derivedtypes_procedure \
+	return_array \
 	optional_string \
 	long_subroutine_name \
 	kind_map_default

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -26,7 +26,8 @@ EXAMPLES = arrayderivedtypes \
 	return_array \
 	optional_string \
 	long_subroutine_name \
-	kind_map_default
+	kind_map_default \
+	intent_out_size
 
 PYTHON = python
 

--- a/examples/docstring/Makefile
+++ b/examples/docstring/Makefile
@@ -31,12 +31,8 @@ main.o: ${F90_SRC}
 ${F90WRAP_SRC}: ${OBJ}
 	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
 
-f90wrap: ${F90WRAP_SRC}
-
 f2py: ${F90WRAP_SRC}
 	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
 
-wrapper: f2py
-
-test: wrapper
+test: f2py
 	python docstring_test.py

--- a/examples/docstring/docstring_test.py
+++ b/examples/docstring/docstring_test.py
@@ -21,34 +21,55 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.__doc__
     ref_docstring = """
-      Module m_circle
-
-
-      Defined at main.f90 lines 7-89
-
       File: main.f90
-      Brief: Test program docstring
+      Test program docstring
+
       Author: test_author
       Copyright: test_copyright
+
+      Module m_circle
+      Defined at main.f90 lines 7-89
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
 
-  def test_docstring(self):
+  def test_subroutine_docstring(self):
     circle = m_circle.t_circle()
     docstring = m_circle.construct_circle.__doc__
     ref_docstring = """
+    Initialize circle
+
     construct_circle(self, radius)
-
-
     Defined at main.f90 lines 17-20
 
     Parameters
     ----------
-    circle : T_Circle, [in,out] t_circle to initialize
-    radius : float, [in] radius of the circle
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
+    """
 
-    Brief: Initialize circle
+    assert clean_str(ref_docstring) == clean_str(docstring)
+
+  def test_subroutine_docstring_more_doc(self):
+    circle = m_circle.t_circle()
+    docstring = m_circle.construct_circle_more_doc.__doc__
+    ref_docstring = """
+    Initialize circle with more doc
+
+    Author: test_author
+    Copyright: test_copyright
+
+    construct_circle_more_doc(self, radius)
+    Defined at main.f90 lines 17-20
+
+    Parameters
+    ----------
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
@@ -57,17 +78,17 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.no_direction.__doc__
     ref_docstring = """
+    Without direction
+
     no_direction(self, radius)
-
-
     Defined at main.f90 lines 28-31
 
     Parameters
     ----------
-    circle : T_Circle, t_circle to initialize
-    radius : float, radius of the circle
-
-    Brief: Without direction
+    circle : T_Circle
+        t_circle to initialize
+    radius : float32
+        radius of the circle
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
@@ -76,17 +97,16 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.incomplete_doc_sub.__doc__
     ref_docstring = """
+    Incomplete doc
+
     incomplete_doc_sub(self, radius)
-
-
     Defined at main.f90 lines 38-41
 
     Parameters
     ----------
     circle : T_Circle
-    radius : float, [in] radius of the circle
-
-    Brief: Incomplete doc
+    radius : float32
+        radius of the circle [in]
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
@@ -95,17 +115,15 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.output_1.__doc__
     ref_docstring = """
+    subroutine output_1 outputs 1
+
     output = output_1()
-
-
     Defined at main.f90 lines 59-61
-
 
     Returns
     -------
-    output : float, [out] this is 1
-
-    Brief: subroutine output_1 outputs 1
+    output : float32
+        this is 1 [out]
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
@@ -114,20 +132,20 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.function_2.__doc__
     ref_docstring = """
+    this is a function
+
     function_2 = function_2(input)
-
-
     Defined at main.f90 lines 69-71
 
     Parameters
     ----------
-    input : str, [in] value
+    input : str
+        value [in]
 
     Returns
     -------
-    function_2 : int, return value
-
-    Brief: this is a function
+    function_2 : int32
+        return value
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
@@ -136,18 +154,19 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.details_doc.__doc__
     ref_docstring = """
+    Initialize circle
+
+    Those are very informative details
+
     details_doc(self, radius)
-
-
     Defined at main.f90 lines 80-82
 
     Parameters
     ----------
-    circle : T_Circle, [in,out] t_circle to initialize
-    radius : float, [in] radius of the circle
-
-    Brief: Initialize circle
-    Details: Those are very informative details
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)
@@ -157,17 +176,17 @@ class TestDocstring(unittest.TestCase):
     circle = m_circle.t_circle()
     docstring = m_circle.doc_inside.__doc__
     ref_docstring = """
+    Doc inside
+
     doc_inside(self, radius)
-
-
     Defined at main.f90 lines 43-52
 
     Parameters
     ----------
-    circle : T_Circle, [in,out] t_circle to initialize
-    radius : float, [in] radius of the circle
-
-    Brief: Doc inside
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
     """
 
     assert clean_str(ref_docstring) == clean_str(docstring)

--- a/examples/docstring/main.f90
+++ b/examples/docstring/main.f90
@@ -12,7 +12,8 @@ module m_circle
      real :: radius
   end type t_circle
 
-  public :: construct_circle,incomplete_doc_sub
+  public :: construct_circle,construct_circle_more_doc
+  public :: incomplete_doc_sub
   public :: no_direction,doc_inside
   public :: output_1,function_2,details_doc
 
@@ -29,6 +30,20 @@ contains
     real, intent(in) :: radius
     circle%radius = radius
   end subroutine construct_circle
+
+    !===========================================================================
+    !>
+    !! \brief Initialize circle with more doc
+    !! \author test_author
+    !! \copyright test_copyright
+    !! \param[in,out] circle      t_circle to initialize
+    !! \param[in]     radius      radius of the circle
+    !<
+  subroutine construct_circle_more_doc(circle,radius)
+    type(t_circle) :: circle
+    real, intent(in) :: radius
+    circle%radius = radius
+  end subroutine construct_circle_more_doc
 
     !===========================================================================
     !>

--- a/examples/intent_out_size/Makefile
+++ b/examples/intent_out_size/Makefile
@@ -1,0 +1,38 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC          = gcc
+F90         = gfortran
+PYTHON      = python
+CFLAGS      = -fPIC
+F90FLAGS    = -fPIC
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v
+F2PYFLAGS   = --build-dir build
+F90WRAP     = f90wrap
+F2PY        = f2py-f90wrap
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+main.o: ${F90_SRC}
+	${F90} ${F90FLAGS} -c $< -o $@
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+f2py: ${F90WRAP_SRC}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
+
+test: f2py
+	${PYTHON} tests.py

--- a/examples/intent_out_size/Makefile.meson
+++ b/examples/intent_out_size/Makefile.meson
@@ -1,0 +1,6 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+
+test: build
+	$(PYTHON) tests.py

--- a/examples/intent_out_size/main.f90
+++ b/examples/intent_out_size/main.f90
@@ -1,0 +1,26 @@
+module m_intent_out
+
+  implicit none
+  public
+
+contains
+
+  subroutine interpolation(n1,n2,a1,a2,output)
+    !
+    integer,                   intent(in)    :: n1,n2
+    real,dimension(n1,n2),     intent(in)    :: a1,a2
+    real,dimension(n1,n2),     intent(out)   :: output
+
+    integer :: i,j
+
+    do j=1,n2
+      do i=1,n1
+         output(i,j)=(a1(i,j)+a2(i,j))/2
+      enddo
+    enddo
+
+  end subroutine interpolation
+
+end module m_intent_out
+
+

--- a/examples/intent_out_size/tests.py
+++ b/examples/intent_out_size/tests.py
@@ -1,0 +1,24 @@
+import unittest
+import numpy as np
+
+from pywrapper import m_intent_out
+
+class TestIntentOut(unittest.TestCase):
+
+  def test_intent_out_size(self):
+
+    a1 = np.array([[1,2], [3,4]], dtype=np.float32, order='F')
+    a2 = np.array([[2,4], [6,8]], dtype=np.float32, order='F')
+    output = np.zeros((2,2), dtype=np.float32, order='F')
+    n1 = 2
+    n2 = 2
+
+    m_intent_out.interpolation(n1,n2,a1,a2,output)
+
+    ref_out = np.array([[1.5,3.], [4.5,6.]], dtype=np.float32, order='F')
+
+    np.testing.assert_array_equal(output, ref_out)
+
+if __name__ == '__main__':
+
+  unittest.main()

--- a/examples/optional_string/Makefile.meson
+++ b/examples/optional_string/Makefile.meson
@@ -1,6 +1,7 @@
 include ../make.meson.inc
 
 NAME     := pywrapper
+WRAPFLAGS += --type-check
 
 test: build
 	$(PYTHON) test.py

--- a/examples/optional_string/main.f90
+++ b/examples/optional_string/main.f90
@@ -3,6 +3,7 @@ module m_string_test
   implicit none
   private
   public :: string_in
+  public :: string_in_array
   public :: string_to_string
   public :: string_to_string_array
   public :: string_out
@@ -13,6 +14,19 @@ contains
 
   subroutine string_in(input)
     character(len=*), intent(in) :: input
+  end subroutine
+
+  subroutine string_in_array(input)
+    character(len=6), intent(in) :: input(:)
+    integer :: i
+
+    if (input(1).ne."one   ") then
+      call f90wrap_abort("First char input is incorrect, should be 'one', but is '" // input(1) // "'" )
+    endif
+
+    if (input(2).ne."two   ") then
+      call f90wrap_abort("Second char input is incorrect, should be 'two', but is '" // input(2) // "'" )
+    endif
   end subroutine
 
   subroutine string_to_string(input,output)

--- a/examples/optional_string/test.py
+++ b/examples/optional_string/test.py
@@ -15,6 +15,44 @@ class TestTypeCheck(unittest.TestCase):
     def test_string_in_3(self):
         m_string_test.string_in(np.bytes_('yo'))
 
+    def test_string_in_4(self):
+        with self.assertRaises(TypeError):
+            m_string_test.string_in(np.array(['yo']))
+
+    @unittest.skipIf(version.parse(np.version.version) > version.parse("1.23.5") , "This test is known to fail on numpy version newer than 1.23.5, dtype=c should not be used")
+    def test_string_in_array_deprecated(self):
+        in_array = np.array(['one   ', 'two   '], dtype='c')
+        m_string_test.string_in_array(in_array)
+
+    @unittest.skipIf(version.parse(np.version.version) > version.parse("1.23.5") , "This test is known to fail on numpy version newer than 1.23.5, dtype=c should not be used")
+    def test_string_in_array_2_deprecated(self):
+        in_array = np.array(['three ', 'two   '], dtype='c')
+        with self.assertRaises(RuntimeError) as context:
+          m_string_test.string_in_array(in_array)
+
+    @unittest.skipIf(version.parse(np.version.version) > version.parse("1.23.5") , "This test is known to fail on numpy version newer than 1.23.5, dtype=c should not be used")
+    def test_string_in_array_3_deprecated(self):
+        in_array = np.array(['one   ', 'four  '], dtype='c')
+        with self.assertRaises(RuntimeError) as context:
+          m_string_test.string_in_array(in_array)
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
+    def test_string_in_array(self):
+        in_array = np.array(['one   ', 'two   '], dtype='S6')
+        m_string_test.string_in_array(in_array)
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
+    def test_string_in_array_2(self):
+        in_array = np.array(['three ', 'two   '], dtype='S6')
+        with self.assertRaises(RuntimeError) as context:
+          m_string_test.string_in_array(in_array)
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
+    def test_string_in_array_3(self):
+        in_array = np.array(['one   ', 'four  '], dtype='S6')
+        with self.assertRaises(RuntimeError) as context:
+          m_string_test.string_in_array(in_array)
+
     def test_string_to_string(self):
         in_string = 'yo'
         out_string = m_string_test.string_to_string(in_string)

--- a/examples/return_array/Makefile
+++ b/examples/return_array/Makefile
@@ -1,0 +1,38 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC          = gcc
+F90         = gfortran
+PYTHON      = python
+CFLAGS      = -fPIC
+F90FLAGS    = -fPIC
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v
+F2PYFLAGS   = --build-dir build
+F90WRAP     = f90wrap
+F2PY        = f2py-f90wrap
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+main.o: ${F90_SRC}
+	${F90} ${F90FLAGS} -c $< -o $@
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+f2py: ${F90WRAP_SRC}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
+
+test: f2py
+	${PYTHON} test.py

--- a/examples/return_array/Makefile.meson
+++ b/examples/return_array/Makefile.meson
@@ -1,0 +1,6 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+
+test: build
+	$(PYTHON) tests.py

--- a/examples/return_array/main.f90
+++ b/examples/return_array/main.f90
@@ -1,0 +1,164 @@
+module m_test
+  implicit none
+  private
+
+  type, public :: t_array_wrapper
+     integer :: a_size
+     real,allocatable :: a_data(:)
+  end type t_array_wrapper
+
+  type, public :: t_array_2d_wrapper
+     integer :: a_size_x, a_size_y
+     real,allocatable :: a_data(:,:)
+  end type t_array_2d_wrapper
+
+  type, public :: t_array_double_wrapper
+     type(t_array_wrapper)  array_wrapper
+  end type t_array_double_wrapper
+
+  type, public :: t_value
+     real :: value
+  end type t_value
+
+  type, public :: t_size_2d
+     integer :: x, y
+  end type t_size_2d
+
+  public :: array_init, array_free
+  public :: array_wrapper_init
+  public :: array_2d_init
+  public :: return_scalar
+  public :: return_hard_coded_1d
+  public :: return_hard_coded_2d
+  public :: return_array_member
+  public :: return_array_member_2d
+  public :: return_array_member_wrapper
+  public :: return_array_input
+  public :: return_array_input_2d
+  public :: return_array_size
+  public :: return_array_size_2d_in
+  public :: return_array_size_2d_out
+  public :: return_derived_type_value
+
+contains
+
+  subroutine array_init(in_array, in_size)
+    type(t_array_wrapper), intent(inout)  :: in_array
+    integer, intent(in)                   :: in_size
+
+    in_array%a_size = in_size
+    allocate(in_array%a_data(in_array%a_size))
+    in_array%a_data = 1
+  end subroutine array_init
+
+  subroutine array_2d_init(in_array, in_size_x, in_size_y)
+    type(t_array_2d_wrapper), intent(inout)   :: in_array
+    integer, intent(in)                       :: in_size_x, in_size_y
+
+    in_array%a_size_x = in_size_x
+    in_array%a_size_y = in_size_y
+    allocate(in_array%a_data(in_array%a_size_x, in_array%a_size_y))
+    in_array%a_data = 2
+  end subroutine array_2d_init
+
+  subroutine array_wrapper_init(in_wrapper, in_size)
+    type(t_array_double_wrapper), intent(inout)  :: in_wrapper
+    integer, intent(in)                   :: in_size
+
+    in_wrapper%array_wrapper%a_size = in_size
+    allocate(in_wrapper%array_wrapper%a_data(in_wrapper%array_wrapper%a_size))
+    in_wrapper%array_wrapper%a_data = 2
+  end subroutine array_wrapper_init
+
+  subroutine array_free(in_array)
+    type(t_array_wrapper), intent(inout)  :: in_array
+
+    in_array%a_size = 0
+    deallocate(in_array%a_data)
+  end subroutine array_free
+
+  function return_scalar(in_array)
+    type(t_array_wrapper), intent(inout)  :: in_array
+    real                                  :: return_scalar
+
+    return_scalar=in_array%a_data(1)
+  end function return_scalar
+
+  function return_hard_coded_1d() result(retval)
+    real                                  :: retval(10)
+
+    retval=2
+  end function return_hard_coded_1d
+
+  function return_hard_coded_2d() result(retval)
+    real                                  :: retval(5,6)
+
+    retval=3
+  end function return_hard_coded_2d
+
+  function return_array_member(in_array) result(retval)
+    type(t_array_wrapper), intent(inout)  :: in_array
+    real                                  :: retval(in_array%a_size)
+
+    retval=in_array%a_data
+  end function return_array_member
+
+  function return_array_member_2d(in_array) result(retval)
+    type(t_array_2d_wrapper), intent(inout)   :: in_array
+    real                                      :: retval(in_array%a_size_x, in_array%a_size_y)
+
+    retval=in_array%a_data
+  end function return_array_member_2d
+
+  function return_array_member_wrapper(in_wrapper) result(retval)
+    type(t_array_double_wrapper), intent(inout)  :: in_wrapper
+    real                                  :: retval(in_wrapper%array_wrapper%a_size)
+
+    retval=in_wrapper%array_wrapper%a_data
+  end function return_array_member_wrapper
+
+  function return_array_input(in_len) result(retval)
+    integer,   intent(in)  :: in_len
+    real :: retval(in_len)
+
+    retval = 1
+  end function return_array_input
+
+  function return_array_input_2d(in_len_x, in_len_y) result(retval)
+    integer,   intent(in)  :: in_len_x,in_len_y
+    real :: retval(in_len_x, in_len_y)
+
+    retval = 2
+  end function return_array_input_2d
+
+  function return_array_size(in_array) result(retval)
+    real,   intent(in)  :: in_array(:)
+    real :: retval(size(in_array))
+
+    retval = 1
+  end function return_array_size
+
+  function return_array_size_2d_in(in_array) result(retval)
+    real,   intent(in)  :: in_array(:,:)
+    real :: retval(size(in_array,2))
+
+    retval = 1
+  end function return_array_size_2d_in
+
+  function return_array_size_2d_out(in_array_1, in_array_2) result(retval)
+    real,   intent(in)  :: in_array_1(:,:)
+    real,   intent(in)  :: in_array_2(:,:)
+    real :: retval(size(in_array_1,1), size(in_array_2,2))
+
+    retval = 2
+  end function return_array_size_2d_out
+
+  function return_derived_type_value(this,size_2d) result(output)
+    type(t_value),    intent(in)  :: this
+    type(t_size_2d),  intent(in)  :: size_2d
+    real                          :: output(size_2d%x,size_2d%y)
+
+    output = this%value
+  end function return_derived_type_value
+
+end module m_test

--- a/examples/return_array/test.py
+++ b/examples/return_array/test.py
@@ -1,0 +1,135 @@
+import unittest
+import numpy as np
+
+from pywrapper import m_test
+
+class TestReturnArray(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestReturnArray, self).__init__(*args, **kwargs)
+        self._shape = (2,)
+        self._array = m_test.t_array_wrapper()
+        m_test.array_init(self._array, *self._shape)
+
+
+    def test_init(self):
+        array = m_test.t_array_wrapper()
+        m_test.array_init(array, 2)
+
+    def test_free(self):
+        array = m_test.t_array_wrapper()
+        m_test.array_init(array, 2)
+        m_test.array_free(array)
+
+    def test_return_scalar(self):
+        out_scalar = m_test.return_scalar(self._array)
+
+        assert(isinstance(out_scalar, float))
+        assert(out_scalar == 1)
+
+    def test_return_hard_coded_1d(self):
+        out_array = m_test.return_hard_coded_1d()
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == (10,))
+        assert((out_array == 2).all)
+
+    def test_return_hard_coded_2d(self):
+        out_array = m_test.return_hard_coded_2d()
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == (5,6))
+        assert((out_array == 3).all)
+
+    def test_return_array_member(self):
+        out_array = m_test.return_array_member(self._array)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == self._shape)
+        assert((out_array == 1).all)
+
+    def test_return_array_member_2d(self):
+        shape = (3,4)
+        array_2d = m_test.t_array_2d_wrapper()
+        m_test.array_2d_init(array_2d, *shape)
+
+        out_array = m_test.return_array_member_2d(array_2d)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == shape)
+        assert((out_array == 2).all)
+
+    def test_return_array_member_wrapper(self):
+        shape = (3,)
+        array_wrapper = m_test.t_array_double_wrapper()
+        m_test.array_wrapper_init(array_wrapper, *shape)
+
+        out_array = m_test.return_array_member_wrapper(array_wrapper)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == shape)
+        assert((out_array == 2).all)
+
+    def test_return_array_input(self):
+        shape = (4,)
+        out_array = m_test.return_array_input(*shape)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == shape)
+        assert((out_array == 1).all)
+
+    def test_return_array_input_2d(self):
+        shape = (5,4)
+        out_array = m_test.return_array_input_2d(*shape)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == shape)
+        assert((out_array == 2).all)
+
+    def test_return_array_size(self):
+        shape = (2,)
+        in_array = np.zeros(shape, dtype=np.float32, order="F")
+        out_array = m_test.return_array_size(in_array)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == shape)
+        assert((out_array == 1).all)
+
+    def test_return_array_size_2d_in(self):
+        shape = (2, 3)
+        in_array = np.zeros(shape, dtype=np.float32, order="F")
+        out_array = m_test.return_array_size_2d_in(in_array)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == (shape[1],))
+        assert((out_array == 1).all)
+
+    def test_return_array_size_2d_out(self):
+        shape_1 = (2, 3)
+        shape_2 = (5, 4)
+        in_array_1 = np.zeros(shape_1, dtype=np.float32, order="F")
+        in_array_2 = np.zeros(shape_2, dtype=np.float32, order="F")
+        out_array = m_test.return_array_size_2d_out(in_array_1, in_array_2)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == (shape_1[0], shape_2[1]))
+        assert((out_array == 2).all)
+
+    def test_return_derived_type_value(self):
+        out_value = 1
+        value_type = m_test.t_value()
+        value_type.value = out_value
+        shape = (2, 3)
+        size_2d = m_test.t_size_2d()
+        size_2d.x = shape[0]
+        size_2d.y = shape[1]
+
+        out_array = m_test.return_derived_type_value(value_type, size_2d)
+
+        assert(isinstance(out_array, np.ndarray))
+        assert(out_array.shape == shape)
+        assert((out_array == out_value).all)
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/examples/string_array_input_f2py/Makefile
+++ b/examples/string_array_input_f2py/Makefile
@@ -1,0 +1,34 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+F90         = gfortran
+PYTHON      = python3
+CFLAGS      = -fPIC
+F90FLAGS    = -fPIC
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+SIGNATURES	= _signatures.pyf
+F2PYFLAGS   = --build-dir build
+F2PY        = f2py
+LINK		= -lgfortran
+.PHONY: all clean
+
+all: f2py test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}_*.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}_*/ ${SIGNATURES}
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${SIGNATURES}: ${F90_SRC}
+	${F2PY} ${F90_SRC} -m _${PY_MOD}_sign -h ${SIGNATURES}
+
+f2py: ${OBJ} ${SIGNATURES}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD}_sign ${F2PYFLAGS} ${LINK} ${OBJ} ${SIGNATURES}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD}_no_sign ${F2PYFLAGS} ${F90_SRC}
+
+test: f2py
+	${PYTHON} tests.py

--- a/examples/string_array_input_f2py/Makefile.meson
+++ b/examples/string_array_input_f2py/Makefile.meson
@@ -1,0 +1,6 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+
+test: build
+	$(PYTHON) tests.py

--- a/examples/string_array_input_f2py/main.f90
+++ b/examples/string_array_input_f2py/main.f90
@@ -1,0 +1,32 @@
+subroutine string_in_array(n0, input, output)
+  implicit none
+
+  integer :: n0
+  !f2py intent(hide), depend(input) :: n0 = shape(input,0)
+  character*(*), intent(in), dimension(n0) :: input
+  integer, intent(out) :: output
+
+  if(input(1) .eq. "one" .and. input(2) .eq. "two") then
+    output=0
+  else
+    output=1
+  endif
+end subroutine string_in_array
+
+subroutine string_in_array_optional(n0, input, output)
+  implicit none
+
+  integer :: n0
+  !f2py intent(hide), depend(input) :: n0 = shape(input,0)
+  character*(*), intent(in), optional, dimension(n0) :: input
+  integer, intent(out) :: output
+
+  output=2
+  if(present(input)) then
+    if(input(1) .eq. "one" .and. input(2) .eq. "two") then
+      output=0
+    else
+      output=1
+    endif
+  endif
+end subroutine string_in_array_optional

--- a/examples/string_array_input_f2py/tests.py
+++ b/examples/string_array_input_f2py/tests.py
@@ -1,0 +1,64 @@
+import unittest
+import numpy as np
+from packaging import version
+
+import _pywrapper_sign
+import _pywrapper_no_sign
+
+class TestWithSignature(unittest.TestCase):
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "f2py bug solved https://github.com/numpy/numpy/issues/24706")
+    def test_string_in_array(self):
+        in_array = np.array(['one', 'two'], dtype='S3')
+        output = _pywrapper_sign.string_in_array(in_array)
+        self.assertEqual(output, 0)
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "f2py bug solved https://github.com/numpy/numpy/issues/24706")
+    def test_string_in_array_optional_present(self):
+        in_array = np.array(['one', 'two'], dtype='S3')
+        output = _pywrapper_sign.string_in_array_optional(in_array)
+        self.assertEqual(output, 0)
+
+    def test_string_in_array_optional_not_present(self):
+        with self.assertRaises((SystemError, ValueError)):
+            _ = _pywrapper_sign.string_in_array_optional()
+
+class TestWithoutSignature(unittest.TestCase):
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0, dtype=S# does not work")
+    def test_string_in_array(self):
+        in_array = np.array(['one', 'two'], dtype='S3')
+        output = _pywrapper_no_sign.string_in_array(in_array)
+        self.assertEqual(output, 0)
+
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0, dtype=S# does not work")
+    def test_string_in_array_optional_present(self):
+        in_array = np.array(['one', 'two'], dtype='S3')
+        output = _pywrapper_no_sign.string_in_array_optional(in_array)
+        self.assertEqual(output, 0)
+
+    def test_string_in_array_optional_not_present(self):
+        with self.assertRaises((SystemError, ValueError)):
+            _ = _pywrapper_no_sign.string_in_array_optional()
+
+class TestWithoutSignatureWithCDtype(unittest.TestCase):
+
+    @unittest.skipIf(version.parse(np.version.version) > version.parse("1.23.5") , "This test is known to fail on numpy version newer than 1.23.5, dtype=c should not be used")
+    def test_string_in_array(self):
+        in_array = np.array(['one', 'two'], dtype='c')
+        output = _pywrapper_no_sign.string_in_array(in_array)
+        self.assertEqual(output, 0)
+
+    @unittest.skipIf(version.parse(np.version.version) > version.parse("1.23.5") , "This test is known to fail on numpy version newer than 1.23.5, dtype=c should not be used")
+    def test_string_in_array_optional_present(self):
+        in_array = np.array(['one', 'two'], dtype='c')
+        output = _pywrapper_no_sign.string_in_array_optional(in_array)
+        self.assertEqual(output, 0)
+
+    def test_string_in_array_optional_not_present(self):
+        with self.assertRaises((SystemError, ValueError)):
+            _ = _pywrapper_no_sign.string_in_array_optional()
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/examples/type_check/Makefile
+++ b/examples/type_check/Makefile
@@ -11,7 +11,7 @@ PY_MOD      = pywrapper
 F90_SRC     = main.f90
 OBJ         = $(F90_SRC:.f90=.o)
 F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
-WRAPFLAGS   = -v --type-check
+WRAPFLAGS   = -v --type-check --kind-map kind.map
 F2PYFLAGS   = --build-dir build
 F90WRAP     = f90wrap
 F2PY        = f2py-f90wrap
@@ -31,12 +31,8 @@ main.o: ${F90_SRC}
 ${F90WRAP_SRC}: ${OBJ}
 	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
 
-f90wrap: ${F90WRAP_SRC}
-
 f2py: ${F90WRAP_SRC}
 	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
 
-wrapper: f2py
-
-test: wrapper
-	python type_check_test.py
+test: f2py
+	${PYTHON} type_check_test.py

--- a/examples/type_check/kind.map
+++ b/examples/type_check/kind.map
@@ -1,0 +1,4 @@
+{\
+'integer':{'1':'signed_char', '2':'short', '4':'int', '8':'long_long'},\
+'real':{'4':'float', '8':'double'},\
+}

--- a/examples/type_check/main.f90
+++ b/examples/type_check/main.f90
@@ -1,5 +1,5 @@
 
-module m_circle
+module m_type_test
   implicit none
   private
 
@@ -17,17 +17,54 @@ module m_circle
   end interface is_circle
 
   interface write_array
+    module procedure write_array_int32_0d
+    module procedure write_array_int64_0d
+    module procedure write_array_real32_0d
+    module procedure write_array_real64_0d
     module procedure write_array_int_1d
     module procedure write_array_int_2d
     module procedure write_array_real
     module procedure write_array_double
+    module procedure write_array_bool
   end interface write_array
+
+  interface optional_scalar
+    module procedure optional_scalar_real
+    module procedure optional_scalar_int
+  end interface optional_scalar
+
+  interface in_scalar
+    module procedure in_scalar_int8
+    module procedure in_scalar_int16
+    module procedure in_scalar_int32
+    module procedure in_scalar_int64
+    module procedure in_scalar_real32
+    module procedure in_scalar_real64
+    module procedure in_array_int64
+    module procedure in_array_real64
+  end interface in_scalar
 
   public :: is_circle
   public :: write_array
   public :: is_circle_circle
   public :: is_circle_square
   public :: write_array_int_1d
+  public :: optional_scalar
+
+  public :: write_array_int64_0d
+  public :: write_array_real64_0d
+  public :: write_array_real
+  public :: write_array_double
+
+  public :: in_scalar
+  public :: in_scalar_int8
+  public :: in_scalar_int16
+  public :: in_scalar_int32
+  public :: in_scalar_int64
+  public :: in_scalar_real32
+  public :: in_scalar_real64
+  public :: in_array_int64
+  public :: in_array_real64
 
 contains
 
@@ -42,6 +79,26 @@ contains
     integer :: output(:)
     output(:) = 0
   end subroutine is_circle_square
+
+  subroutine write_array_int32_0d(output)
+    integer(kind=4),intent(inout) :: output
+    output = 10
+  end subroutine write_array_int32_0d
+
+  subroutine write_array_int64_0d(output)
+    integer(kind=8),intent(inout) :: output
+    output = 11
+  end subroutine write_array_int64_0d
+
+  subroutine write_array_real32_0d(output)
+    real(kind=4),intent(inout) :: output
+    output = 12
+  end subroutine write_array_real32_0d
+
+  subroutine write_array_real64_0d(output)
+    real(kind=8),intent(inout) :: output
+    output = 13
+  end subroutine write_array_real64_0d
 
   subroutine write_array_int_1d(output)
     integer :: output(:)
@@ -63,6 +120,75 @@ contains
     output(:) = 4
   end subroutine write_array_double
 
-end module m_circle
+  subroutine write_array_bool(output)
+    logical :: output(:)
+    output(:) = .true.
+  end subroutine write_array_bool
 
+  subroutine optional_scalar_real(output, opt_output)
+    real, intent(inout)         :: output(:)
+    real, intent(out),optional  :: opt_output
+    output(:) = 10
+    if (present(opt_output)) then
+      opt_output = 20
+    endif
+  end subroutine
 
+  subroutine optional_scalar_int(output, opt_output)
+    integer, intent(inout)         :: output(:)
+    integer, intent(out),optional  :: opt_output
+    output(:) = 15
+    if (present(opt_output)) then
+      opt_output = 25
+    endif
+  end subroutine
+
+  function in_scalar_int8(input) result(output)
+    integer(kind=1),intent(in) :: input
+    integer(kind=4)            :: output
+    output = 108
+  end function in_scalar_int8
+
+  function in_scalar_int16(input) result(output)
+    integer(kind=2),intent(in) :: input
+    integer(kind=4)            :: output
+    output = 116
+  end function in_scalar_int16
+
+  function in_scalar_int32(input) result(output)
+    integer(kind=4),intent(in) :: input
+    integer(kind=4)            :: output
+    output = 132
+  end function in_scalar_int32
+
+  function in_scalar_int64(input) result(output)
+    integer(kind=8),intent(in) :: input
+    integer(kind=4)            :: output
+    output = 164
+  end function in_scalar_int64
+
+  function in_scalar_real32(input) result(output)
+    real(kind=4),intent(in)    :: input
+    integer(kind=4)            :: output
+    output = 232
+  end function in_scalar_real32
+
+  function in_scalar_real64(input) result(output)
+    real(kind=8),intent(in)    :: input
+    integer(kind=4)            :: output
+    output = 264
+  end function in_scalar_real64
+
+  function in_array_int64(input) result(output)
+    integer(kind=8),intent(in) :: input(:)
+    integer(kind=4)            :: output
+    output = 364
+  end function in_array_int64
+
+  function in_array_real64(input) result(output)
+    real(kind=8),intent(in)    :: input(:)
+    integer(kind=4)            :: output
+    output = 464
+  end function in_array_real64
+
+end module m_type_test

--- a/examples/type_check/type_check_test.py
+++ b/examples/type_check/type_check_test.py
@@ -1,86 +1,241 @@
 import unittest
 import numpy as np
+from packaging import version
 
-from pywrapper import m_circle
+from pywrapper import m_type_test
 
 class TestTypeCheck(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(TestTypeCheck, self).__init__(*args, **kwargs)
-        self._circle = m_circle.t_circle()
-        self._square = m_circle.t_square()
+        self._circle = m_type_test.t_circle()
+        self._square = m_type_test.t_square()
 
     def test_derived_type_selection(self):
         out_circle = np.array([-1], dtype=np.int32)
+        out_string = 'yo'
+        out_string = 'yo'
         out_square = np.array([-1], dtype=np.int32)
 
-        m_circle.is_circle(self._circle, out_circle)
-        m_circle.is_circle(self._square, out_square)
+        m_type_test.is_circle(self._circle, out_circle)
+        m_type_test.is_circle(self._square, out_square)
 
-        assert out_circle[0]==1
-        assert out_square[0]==0
+        self.assertEqual(out_circle[0], 1)
+        self.assertEqual(out_square[0], 0)
+
+    def test_shape_selection_0d(self):
+        out = np.array(-1, dtype=np.int32)
+        m_type_test.write_array(out)
+
+        self.assertEqual(out, 10)
+
+    def test_kind_selection_int_0d(self):
+        out = np.array(-1, dtype=np.int64)
+        m_type_test.write_array(out)
+
+        self.assertEqual(out, 11)
+
+    def test_kind_selection_real32_0d(self):
+        out = np.array(-1, dtype=np.float32)
+        m_type_test.write_array(out)
+
+        self.assertEqual(out, 12)
+
+    def test_kind_selection_real64_0d(self):
+        out = np.array(-1, dtype=np.float64)
+        m_type_test.write_array(out)
+
+        self.assertEqual(out, 13)
 
     def test_shape_selection_1d(self):
         out = np.array([-1], dtype=np.int32)
-        m_circle.write_array(out)
+        m_type_test.write_array(out)
 
-        assert out[0]==1
+        self.assertEqual(out[0], 1)
 
     def test_shape_selection_2d(self):
         out = np.array([[-1]], dtype=np.int32)
-        m_circle.write_array(out)
+        m_type_test.write_array(out)
 
-        assert out[0]==2
+        self.assertEqual(out[0], 2)
 
     def test_type_selection(self):
         out = np.array([-1], dtype=np.float32)
-        m_circle.write_array(out)
+        m_type_test.write_array(out)
 
-        assert out[0]==3
+        self.assertEqual(out[0], 3)
 
-    def test_kind_selection(self):
+    def test_kind_selection_float_1d(self):
         out = np.array([-1], dtype=np.float64)
-        m_circle.write_array(out)
+        m_type_test.write_array(out)
 
-        assert out[0]==4
+        self.assertEqual(out[0], 4)
+
+    @unittest.skip("Bool are not supported in interfaces")
+    def test_kind_selection(self):
+        out = np.array([False], dtype=np.bool)
+        m_type_test.write_array(out)
+
+        self.assertEqual(out[0], True)
 
     def test_wrong_derived_type(self):
         out = np.array([-1], dtype=np.int32)
 
         with self.assertRaises(TypeError):
-            m_circle._is_circle_square(self._circle, out)
+            m_type_test.is_circle_square(self._circle, out)
 
         with self.assertRaises(TypeError):
-            m_circle._is_circle_circle(self._square, out)
+            m_type_test.is_circle_circle(self._square, out)
 
     def test_wrong_kind(self):
         out = np.array([-1], dtype=np.int64)
 
         with self.assertRaises(TypeError):
-            m_circle._write_array_int_1d(out)
+            m_type_test.write_array_int_1d(out)
 
     def test_wrong_type(self):
         out = np.array([-1], dtype=np.float32)
 
         with self.assertRaises(TypeError):
-            m_circle._write_array_int_1d(out)
+            m_type_test.write_array_int_1d(out)
 
     def test_wrong_dim(self):
         out = np.array([[-1]], dtype=np.int32)
 
         with self.assertRaises(TypeError):
-            m_circle._write_array_int_1d(out)
+            m_type_test.write_array_int_1d(out)
 
     def test_no_suitable_version(self):
         with self.assertRaises(TypeError):
-            m_circle.is_circle(1., 1.)
+            m_type_test.is_circle(1., 1.)
 
     def test_no_suitable_version_2(self):
         out = np.array([-1], dtype=np.complex128)
 
         with self.assertRaises(TypeError):
-            m_circle.write_array(out)
+            m_type_test.write_array(out)
 
+    def test_optional_scalar_real(self):
+        out = np.array([-1], dtype=np.float32)
+        opt_out = np.array(-1, dtype=np.float32)
+        m_type_test.optional_scalar(out)
+        self.assertEqual(out[0], 10)
+        self.assertEqual(opt_out, -1)
+
+        m_type_test.optional_scalar(out, opt_out)
+        self.assertEqual(out[0], 10)
+        self.assertEqual(opt_out, 20)
+
+    def test_optional_scalar_int(self):
+        out = np.array([-1], dtype=np.int32)
+        opt_out = np.array(-1, dtype=np.int32)
+        m_type_test.optional_scalar(out)
+        self.assertEqual(out[0], 15)
+        self.assertEqual(opt_out, -1)
+
+        m_type_test.optional_scalar(out, opt_out)
+        self.assertEqual(out[0], 15)
+        self.assertEqual(opt_out, 25)
+
+    def test_scalar_out_tolerance_real_32_64(self):
+        out = np.array(-1, dtype=np.float32)
+        with self.assertRaises(TypeError) as context:
+          m_type_test.write_array_real64_0d(out)
+
+    def test_scalar_out_tolerance_int_32_64(self):
+        out = np.array(-1, dtype=np.int32)
+        with self.assertRaises(TypeError) as context:
+          m_type_test.write_array_int64_0d(out)
+
+    def test_array_out_rigid_int_32_64(self):
+        out = np.array([-1], dtype=np.int32)
+        with self.assertRaises(TypeError) as context:
+          m_type_test.write_array_int64_0d(out)
+
+    def test_array_out_rigid_real_32_64(self):
+        out = np.array([-1], dtype=np.float32)
+        with self.assertRaises(TypeError) as context:
+          m_type_test.write_array_double(out)
+
+    def test_scalar_interface_int8(self):
+        intput = np.array(-1, dtype=np.int8)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 108)
+
+    def test_scalar_interface_int16(self):
+        intput = np.array(-1, dtype=np.int16)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 116)
+
+    def test_scalar_interface_int32(self):
+        intput = np.array(-1, dtype=np.int32)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 132)
+
+    def test_scalar_interface_int64(self):
+        intput = np.array(-1, dtype=np.int64)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 164)
+
+    def test_scalar_interface_float32(self):
+        intput = np.array(-1, dtype=np.float32)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 232)
+
+    def test_scalar_interface_float64(self):
+        intput = np.array(-1, dtype=np.float64)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 264)
+
+    def test_array_interface_int64(self):
+        intput = np.array([-1], dtype=np.int64)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 364)
+
+    def test_array_interface_float64(self):
+        intput = np.array([-1], dtype=np.float64)
+        out = m_type_test.in_scalar(intput)
+        self.assertEqual(out, 464)
+
+    def test_scalar_in_int8(self):
+        intput = np.array(-1, dtype=np.int32)
+        out = m_type_test.in_scalar_int8(intput)
+        self.assertEqual(out, 108)
+
+    def test_scalar_in_int16(self):
+        intput = np.array(-1, dtype=np.int32)
+        out = m_type_test.in_scalar_int16(intput)
+        self.assertEqual(out, 116)
+
+    def test_scalar_in_int32(self):
+        intput = np.array(-1, dtype=np.int64)
+        out = m_type_test.in_scalar_int32(intput)
+        self.assertEqual(out, 132)
+
+    def test_scalar_in_int64(self):
+        intput = np.array(-1, dtype=np.int32)
+        out = m_type_test.in_scalar_int64(intput)
+        self.assertEqual(out, 164)
+
+    def test_scalar_in_float32(self):
+        intput = np.array(-1, dtype=np.float64)
+        out = m_type_test.in_scalar_real32(intput)
+        self.assertEqual(out, 232)
+
+    def test_scalar_in_float64(self):
+        intput = np.array(-1, dtype=np.float32)
+        out = m_type_test.in_scalar_real64(intput)
+        self.assertEqual(out, 264)
+
+    def test_array_in_int64(self):
+        intput = np.array([-1], dtype=np.int32)
+        with self.assertRaises(TypeError) as context:
+          out = m_type_test.in_array_int64(intput)
+
+    def test_array_in_float64(self):
+        intput = np.array([-1], dtype=np.float32)
+        with self.assertRaises(TypeError) as context:
+          out = m_type_test.in_array_real64(intput)
 
 if __name__ == '__main__':
 

--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -30,7 +30,6 @@ import numpy as np
 from f90wrap import codegen as cg
 from f90wrap import fortran as ft
 from f90wrap.six import string_types  # Python 2/3 compatibility library
-from f90wrap.transform import ArrayDimensionConverter
 from f90wrap.transform import shorten_long_name
 
 log = logging.getLogger(__name__)
@@ -567,7 +566,7 @@ end type %(typename)s_rec_ptr_type"""
         self.write("integer(c_int), intent(out) :: nd")
         self.write("integer(c_int), intent(out) :: dtype")
         try:
-            rank = len(ArrayDimensionConverter.split_dimensions(dims))
+            rank = len(ft.Argument.split_dimensions(dims))
             if el.type.startswith("character"):
                 rank += 1
         except ValueError:
@@ -627,7 +626,7 @@ end type %(typename)s_rec_ptr_type"""
         """
         if (
             element.type.startswith("type")
-            and len(ArrayDimensionConverter.split_dimensions(dims)) != 1
+            and len(ft.Argument.split_dimensions(dims)) != 1
         ):
             return
 

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -912,9 +912,9 @@ def normalise_type(typename, kind_map):
     return type + kind
 
 
-def fortran_array_type(typename, kind_map):
+def f2numpy_type(typename, kind_map):
     """
-    Convert string repr of Fortran type to equivalent numpy array typenum
+    Convert string repr of Fortran type to equivalent numpy array type
     """
     c_type = f2c_type(typename, kind_map)
 
@@ -936,10 +936,16 @@ def fortran_array_type(typename, kind_map):
 
     if c_type not in c_type_to_numpy_type:
         raise RuntimeError('Unknown C type %s' % c_type)
-
-    # find numpy numerical type code
-    numpy_type = np.dtype(c_type_to_numpy_type[c_type]).num
+    numpy_type = np.dtype(c_type_to_numpy_type[c_type])
     return numpy_type
+
+def fortran_array_type(typename, kind_map):
+    """
+    Convert string repr of Fortran type to equivalent numpy array typenum
+    """
+    # find numpy numerical type code
+    numpy_type_num = f2numpy_type(typename, kind_map).num
+    return numpy_type_num
 
 def f2py_type(type, attributes=None):
     """

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -308,7 +308,37 @@ class Element(Declaration):
 
 class Argument(Declaration):
     __doc__ = _rep_des(Declaration.__doc__, "Represents a Procedure Argument.")
-    pass
+
+    @staticmethod
+    def split_dimensions(dim):
+        """Given a string like "dimension(a,b,c)" return the list of dimensions ['a','b','c']."""
+        dim = dim[10:-1]  # remove "dimension(" and ")"
+        br = 0
+        d = 1
+        ds = ['']
+        for c in dim:
+            if c != ',': ds[-1] += c
+            if c == '(':
+                br += 1
+            elif c == ')':
+                br -= 1
+            elif c == ',':
+                if br == 0:
+                    ds.append('')
+                else:
+                    ds[-1] += ','
+        return ds
+
+    def dims_list(self):
+        dims = list(filter(lambda x: x.startswith("dimension"), self.attributes))
+        if len(dims) > 1:
+            raise ValueError('more than one dimension attribute found for arg %s:\\\n%s' % (self.name, ','.join(dims)))
+        try:
+            ft_array_dims_list = self.split_dimensions(dims[0])
+        except IndexError:
+            ft_array_dims_list = []
+        ft_array_dims_list = [elem.strip(' ') for elem in ft_array_dims_list]
+        return ft_array_dims_list
 
 class Type(Fortran):
     """

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -922,7 +922,7 @@ def normalise_type(typename, kind_map):
     c_type = f2c_type(typename, kind_map)
     c_type_to_fortran_kind = {
         'char' : '',
-        'signed_char' : '',
+        'signed_char' : '(1)',
         'short' : '(2)',
         'int' : '(4)',
         'long_long' : '(8)',

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -857,8 +857,14 @@ def split_type_kind(typename):
     type*kind -> (type, kind)
     type(kind) -> (type, kind)
     type(kind=kind) -> (type, kind)
+    character(len=*) -> (character, *)
     """
-    if '*' in typename:
+
+    if typename.startswith('character'):
+        type = 'character'
+        kind = typename[len('character'):]
+        kind = kind.replace('len=', '')
+    elif '*' in typename:
         type = typename[:typename.index('*')]
         kind = typename[typename.index('*') + 1:]
     elif '(' in typename:

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -25,7 +25,6 @@ import os
 import logging
 import re
 
-from f90wrap.transform import ArrayDimensionConverter
 from f90wrap.transform import shorten_long_name
 from f90wrap import fortran as ft
 from f90wrap import codegen as cg
@@ -815,10 +814,7 @@ return %(el_name)s"""
         self.write()
 
     def write_dt_array_wrapper(self, node, el, dims):
-        if (
-            el.type.startswith("type")
-            and len(ArrayDimensionConverter.split_dimensions(dims)) != 1
-        ):
+        if el.type.startswith("type") and len(ft.Argument.split_dimensions(dims)) != 1:
             return
 
         func_name = "init_array_%s" % el.name

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -24,6 +24,7 @@
 import os
 import logging
 import re
+import numpy as np
 
 from f90wrap.transform import shorten_long_name
 from f90wrap import fortran as ft
@@ -447,6 +448,62 @@ except ValueError:
                         ("None if %(arg_py_name)s is None else %(arg_py_name)s._handle")
                         % {"arg_py_name": arg.py_name},
                     )
+            # Add dimension argument for fortran functions that returns an array
+            if isinstance(node, ft.Function):
+
+                def f902py_name(node, f90_name):
+                    for arg in node.arguments:
+                        if arg.name == f90_name:
+                            return arg.py_name
+                    return ""
+
+                args_py_names = [arg.py_name for arg in node.arguments]
+                offset = 0
+                # Regular arguments are first, compute the index offset
+                for arg in node.arguments:
+                    offset += len(arg.dims_list())
+                for retval in node.ret_val:
+                    the_dim = ""
+                    try:
+                        the_dim = retval.dims_list()[0]
+                    except IndexError:
+                        pass
+                    for dim_str in retval.dims_list():
+                        # "size" is replaced by "size_bn" ("badname") by numpy.f2py
+                        keyword = "size"
+                        try:
+                            keyword = np.f2py.crackfortran.badnames[keyword]
+                        except KeyError:
+                            pass
+                        match = re.search("%s\((.*)\)" % keyword, dim_str)
+
+                        if match:
+                            # Case where return size is size of input
+                            size_arg = match.group(1).split(",")
+                            py_name = f902py_name(node, size_arg[0])
+                            try:
+                                dim_num = int(size_arg[1]) - 1
+                            except IndexError:
+                                dim_num = 0
+                            out_dim = "%s.shape[%d]" % (py_name, dim_num)
+                        else:
+                            # Case where return size is input
+                            py_name = f902py_name(node, dim_str.split("%")[0])
+                            # It could be a member of an object
+                            members_arg = dim_str.split("%")[1:]
+                            if members_arg:
+                                out_dim = "%s.%s" % (py_name, ".".join(members_arg))
+                            else:
+                                out_dim = "%s" % (py_name)
+
+                        if py_name in args_py_names:
+                            log.info("Adding dimension argument to '%s'" % node.name)
+                            dct["f90_arg_names"] = "%s, %s" % (
+                                dct["f90_arg_names"],
+                                "n%d=%s" % (offset, out_dim),
+                            )
+                        offset += 1
+
             call_line = (
                 "%(call)s%(mod_name)s.%(subroutine_name)s(%(f90_arg_names)s)" % dct
             )

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -500,7 +500,7 @@ except ValueError:
                             log.info("Adding dimension argument to '%s'" % node.name)
                             dct["f90_arg_names"] = "%s, %s" % (
                                 dct["f90_arg_names"],
-                                "n%d=%s" % (offset, out_dim),
+                                "f90wrap_n%d=%s" % (offset, out_dim),
                             )
                         offset += 1
 

--- a/f90wrap/transform.py
+++ b/f90wrap/transform.py
@@ -1031,11 +1031,10 @@ class RenameArgumentsPython(ft.FortranVisitor):
 class RenameInterfacesPython(ft.FortranVisitor):
     def visit_Interface(self, node):
         for proc in node.procedures:
-            if hasattr(proc, 'method_name'):
-                proc.method_name = '_' + proc.method_name
-            else:
-                proc.method_name = '_' + proc.name
-        node.method_name = node.name
+            if not hasattr(proc, 'method_name'):
+                proc.method_name = proc.name
+        if not hasattr(node,'method_name'):
+            node.method_name = node.name
         if node.name == 'assignment(=)':
             node.method_name = 'assignment'
         elif node.name == 'operator(+)':


### PR DESCRIPTION
This PR sits on top of #230 and #231
Update the type check feature that checks the Python types that are passed to Fortran routines.
Improves #182:
- Support for optional arguments
- Better support for strings
- Better error messages when it fails
- Be less strict with scalar input:
  When the wrapper is not wrapping a Fortran interface, use numpy `astype` member function to convert types to the right size. For instance, int32 to int64. This makes the Python wrapper interfaces more Pythonic.
  When the wrapper is wrapping a Fortran interface, the behavior stays the same, strict type matching between Python input type and the Fortran signature is required so that the correct Fortran routine is called.