### PR TITLE
Auto error raise

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Citing f90wrap
 If you find `f90wrap` useful in academic work, please cite the following
 (open access) publication:
 
-> J. R. Kermode, f90wrap: an automated tool for constructing 
-> deep Python interfaces to modern Fortran codes. 
-> J. Phys. Condens. Matter (2020) 
+> J. R. Kermode, f90wrap: an automated tool for constructing
+> deep Python interfaces to modern Fortran codes.
+> J. Phys. Condens. Matter (2020)
 >[doi:10.1088/1361-648X/ab82d2](https://dx.doi.org/10.1088/1361-648X/ab82d2)
 
 BibTeX entry:
@@ -103,7 +103,7 @@ applications:
  - [CASTEP](http://www.castep.org) - CasPyTep wrappers for electronic structure code
  - [QEpy](http://qepy.rutgers.edu/index.html) - Python wrapper for Quantum Espresso electronic structure code
 
-See this [Jupyter notebook](https://github.com/jameskermode/f90wrap/blob/master/docs/tutorials/f90wrap-demo.ipynb) 
+See this [Jupyter notebook](https://github.com/jameskermode/f90wrap/blob/master/docs/tutorials/f90wrap-demo.ipynb)
 from a recent seminar for more details.
 
 Usage
@@ -252,6 +252,8 @@ some of the options are used:
       -a ABORT_FUNC, --abort-func ABORT_FUNC
                             Name of Fortran subroutine to invoke if a fatal error
                             occurs
+      --auto-raise-error AUTO_RAISE_ERROR
+                            Generate calls to abort subroutine in f90wrap fortran wrappers: 'err_num_variable,err_msg_variable'
       --only [ONLY [ONLY ...]]
                             Subroutines to include in wrapper
       --skip [SKIP [SKIP ...]]
@@ -276,7 +278,7 @@ some of the options are used:
                             Maximum length of lines in fortan files written.
                             Default: 120
       --type-check          Check for type/shape matching of Python argument with the wrapped Fortran subroutine
-         
+
 
 Author
 ------
@@ -306,7 +308,7 @@ Developer Notes
 Wheels are built on push and pull requests to `master` using cibuildwheel
 with [this workflow](.github/workflows/build-wheels.yml).
 
-To make a release candidate create a tag with a suffix such as `-rc1` for the first attempt, 
+To make a release candidate create a tag with a suffix such as `-rc1` for the first attempt,
 push to trigger the build:
 
 ```bash

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND tests
     output_kind
     remove_pointer_arg
     fortran_oo
+    auto_raise_error
 )
 
 foreach(test ${tests})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,6 +36,9 @@ list(APPEND tests
     output_kind
     remove_pointer_arg
     fortran_oo
+	issue206_subroutine_oldstyle
+	issue227_allocatable
+	issue235_allocatable_classes
     auto_raise_error
 )
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -34,7 +34,8 @@ EXAMPLES = arrayderivedtypes \
 	fortran_oo \
 	issue206_subroutine_oldstyle \
 	issue227_allocatable \
-	issue235_allocatable_classes
+	issue235_allocatable_classes \
+	auto_raise_error
 
 PYTHON = python
 

--- a/examples/auto_raise_error/Makefile
+++ b/examples/auto_raise_error/Makefile
@@ -1,0 +1,38 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+CC          = gcc
+F90         = gfortran
+PYTHON      = python
+CFLAGS      = -fPIC
+F90FLAGS    = -fPIC
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v --auto-raise-error ierr,errmsg
+F2PYFLAGS   = --build-dir build
+F90WRAP     = f90wrap
+F2PY        = f2py-f90wrap
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+main.o: ${F90_SRC}
+	${F90} ${F90FLAGS} -c $< -o $@
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+f2py: ${F90WRAP_SRC}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
+
+test: f2py
+	${PYTHON} tests.py

--- a/examples/auto_raise_error/Makefile.meson
+++ b/examples/auto_raise_error/Makefile.meson
@@ -1,0 +1,6 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+
+test: build
+	$(PYTHON) tests.py

--- a/examples/auto_raise_error/Makefile.meson
+++ b/examples/auto_raise_error/Makefile.meson
@@ -1,6 +1,7 @@
 include ../make.meson.inc
 
 NAME     := pywrapper
+WRAPFLAGS += --auto-raise-error ierr,errmsg
 
 test: build
 	$(PYTHON) tests.py

--- a/examples/auto_raise_error/main.f90
+++ b/examples/auto_raise_error/main.f90
@@ -1,0 +1,73 @@
+module m_error
+  implicit none
+  private
+
+  public :: auto_raise,auto_no_raise
+  public :: auto_raise_optional,auto_no_raise_optional
+  public :: no_error_var
+
+contains
+
+  subroutine auto_raise(ierr,errmsg)
+
+    implicit none
+    integer,          intent(out) :: ierr
+    character(len=*), intent(out) :: errmsg
+
+    ierr=1
+    write(errmsg,'(a)') 'auto raise error'
+    return
+
+  end subroutine
+
+  subroutine auto_raise_optional(ierr,errmsg)
+
+    implicit none
+    integer,optional,          intent(out) :: ierr
+    character(len=*),optional, intent(out) :: errmsg
+
+    ierr=1
+    write(errmsg,'(a)') 'auto raise error optional'
+    return
+
+  end subroutine
+
+  subroutine auto_no_raise(ierr,errmsg)
+
+    implicit none
+    integer,          intent(out) :: ierr
+    character(len=*), intent(out) :: errmsg
+
+    ierr=0
+    write(errmsg,'(a)') ''
+    return
+
+  end subroutine
+
+  subroutine auto_no_raise_optional(ierr,errmsg)
+
+    implicit none
+    integer,optional,          intent(out) :: ierr
+    character(len=*),optional, intent(out) :: errmsg
+
+    ierr=0
+    write(errmsg,'(a)') ''
+    return
+
+  end subroutine
+
+  subroutine no_error_var(a_num,a_string)
+
+    implicit none
+    integer,          intent(out) :: a_num
+    character(len=*), intent(out) :: a_string
+
+    a_num=1
+    write(a_string,'(a)') 'a string'
+    return
+
+  end subroutine
+
+
+
+end module m_error

--- a/examples/auto_raise_error/tests.py
+++ b/examples/auto_raise_error/tests.py
@@ -1,0 +1,39 @@
+import unittest
+import numpy as np
+
+from pywrapper import m_error
+
+class TestError(unittest.TestCase):
+
+    def test_raise(self):
+        with self.assertRaises(RuntimeError) as context:
+            m_error.auto_raise()
+        self.assertEqual(str(context.exception).strip(), 'auto raise error')
+
+    def test_raise_optional(self):
+        with self.assertRaises(RuntimeError) as context:
+            m_error.auto_raise_optional()
+        self.assertEqual(str(context.exception).strip(), 'auto raise error optional')
+
+    def test_no_raise(self):
+        m_error.auto_no_raise()
+        # Check that Error handling argument are correctly removed from interface
+        with self.assertRaises(TypeError):
+            ierr, errmsg = m_error.auto_no_raise()
+
+    def test_no_raise_optional(self):
+        m_error.auto_no_raise_optional()
+        # Check that Error handling argument are correctly removed from interface
+        with self.assertRaises(TypeError):
+            ierr=1
+            errmsg='error'
+            m_error.auto_no_raise_optional(ierr, errmsg)
+
+    def test_no_error_var(self):
+        a_number, a_string = m_error.no_error_var()
+        self.assertEqual(a_number, 1)
+        self.assertEqual(a_string, b'a string')
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/examples/issue235_allocatable_classes/Makefile
+++ b/examples/issue235_allocatable_classes/Makefile
@@ -21,5 +21,5 @@ f90wrapper: mytype.f90 myclass.f90 myclass_factory.f90
 clean:
 	rm -f *.o f90wrap*.f90 *.so *.mod
 	rm -rf src.*/
-	rm -rf itest/
+	rm -rf itest.py
 	-rm -rf src.*/ .f2py_f2cmap .libs/ __pycache__/

--- a/f90wrap/scripts/main.py
+++ b/f90wrap/scripts/main.py
@@ -143,6 +143,8 @@ USAGE
                             help="Generate a Python package instead of a single module")
         parser.add_argument('-a', '--abort-func', default='f90wrap_abort',
                             help='Name of Fortran subroutine to invoke if a fatal error occurs')
+        parser.add_argument('--auto-raise-error', type=str, default='',
+                            help="Generate calls to abort subroutine in f90wrap fortran wrappers: 'err_num_variable,err_msg_variable'")
         parser.add_argument("--only", nargs="*", default=[], help="Subroutines to include in wrapper")
         parser.add_argument("--skip", nargs="*", default=[],
                             help="Subroutines to exclude modules and subroutines from wrapper")
@@ -389,12 +391,15 @@ USAGE
                                       py_mod_names=py_mod_names,
                                       class_names=class_names,
                                       max_length=py_max_line_length,
+                                      auto_raise=auto_raise_error,
                                       type_check=type_check,
                                       relative = relative,
                                       ).visit(py_tree)
         fwrap.F90WrapperGenerator(prefix, fsize, string_lengths,
                                   abort_func, kind_map, types, default_to_inout,
-                                  max_length=f90_max_line_length).visit(f90_tree)
+                                  max_length=f90_max_line_length,
+                                  default_string_length=default_string_length,
+                                  auto_raise=auto_raise_error).visit(f90_tree)
         return 0
 
     except KeyboardInterrupt:


### PR DESCRIPTION
Add a flag to automatically generate calls to the abort function in the f90wrap Fortran wrappers to raise Python RuntimeErrors.

To my knowledge, there is no standard way of handling errors in Fortran; this feature matches the way we handle errors in our code and might match the way others handle errors.
In our Fortran code, subroutines use one integer variable that holds the error code and one character variable that holds the error message. If the error code is different from 0, the program stops, and a call stack is built via the error character variable.
The flag allows specifying the variable names used in the wrapped code for error handling and generates a call to `f90wrap_abort` in the f90wrap Fortran wrappers, which is called if the error code is different from 0.
The added examples might give a clearer idea of this explanation.

This enables us to avoid having to add calls to `f90wrap_abort` in the wrapped code and still get the Fortran error raised in the Python wrappers.