### PR TITLE
fix issue 258 - incorrect generation of getter functions for polymorphic derived types

### DIFF
--- a/examples/issue258_derived_type_attributes/Makefile
+++ b/examples/issue258_derived_type_attributes/Makefile
@@ -1,0 +1,24 @@
+FC = gfortran
+FCFLAGS = -fPIC
+PYTHON = python
+
+all: test
+
+test: wrapper
+	$(PYTHON) test.py
+
+wrapper: wrap-dta_tt wrap-dta_tc wrap-dta_ct wrap-dta_cc
+
+wrap-%: f90wrap_%.f90 %.o
+	f2py-f90wrap --build-dir . -c -m _$* --opt="-O0 -g" f90wrap_$*.f90 $*.o 
+
+f90wrap_%.f90 %.py: %.o %.f90
+	f90wrap -m $* $*.f90 -v
+
+%.o: %.f90
+	$(FC) $(FCFLAGS) -c -g -O0 $< -o $@
+
+clean:
+	rm -f *.o f90wrap*.f90 *.so *.mod *.x .f2py_f2cmap
+	rm -rf src.*/ .libs/ __pycache__/
+	rm -rf dta_*.py

--- a/examples/issue258_derived_type_attributes/dta_cc.f90
+++ b/examples/issue258_derived_type_attributes/dta_cc.f90
@@ -1,0 +1,62 @@
+module dta_cc
+    implicit none
+    
+    type :: t_inner
+        integer :: value
+        contains
+        procedure :: print => t_inner_print
+    end type t_inner
+
+    type :: t_outer
+        integer :: value
+        type(t_inner) :: inner
+        contains
+        procedure :: print => t_outer_print
+    end type t_outer
+
+    interface t_inner
+        module procedure new_inner
+    end interface t_inner
+
+    interface t_outer
+        module procedure new_outer
+    end interface t_outer
+
+    contains
+
+    function new_inner(value) result(inner)
+        type(t_inner) :: inner
+        integer, intent(in) :: value
+
+        inner%value = value
+    end function new_inner
+
+    function new_outer(value, inner) result(node)
+        type(t_outer) :: node
+        integer, intent(in) :: value
+        type(t_inner), intent(in) :: inner
+
+        node%inner = inner
+        node%value = value
+    end function new_outer
+
+    subroutine t_inner_print(inner)
+        class(t_inner), intent(in) :: inner
+
+        write(*,*) "value:", inner%value
+    end subroutine t_inner_print
+
+    subroutine t_outer_print(outer)
+        class(t_outer), intent(in) :: outer
+
+        write(*,*) "value:", outer%value, " inner value:", outer%inner%value
+    end subroutine t_outer_print
+
+    function get_outer_inner(outer) result(inner)
+        type(t_outer), intent(in) :: outer
+        type(t_inner) :: inner
+
+        inner = outer%inner
+    end function get_outer_inner
+
+end module dta_cc

--- a/examples/issue258_derived_type_attributes/dta_ct.f90
+++ b/examples/issue258_derived_type_attributes/dta_ct.f90
@@ -1,0 +1,54 @@
+module dta_ct
+    implicit none
+    
+    type :: t_inner
+        integer :: value
+    end type t_inner
+
+    type :: t_outer
+        integer :: value
+        type(t_inner) :: inner
+        contains
+        procedure :: print => t_outer_print
+    end type t_outer
+
+    interface t_inner
+        module procedure new_inner
+    end interface t_inner
+
+    interface t_outer
+        module procedure new_outer
+    end interface t_outer
+
+    contains
+
+    function new_inner(value) result(inner)
+        type(t_inner) :: inner
+        integer, intent(in) :: value
+
+        inner%value = value
+    end function new_inner
+
+    function new_outer(value, inner) result(node)
+        type(t_outer) :: node
+        integer, intent(in) :: value
+        type(t_inner), intent(in) :: inner
+
+        node%inner = inner
+        node%value = value
+    end function new_outer
+
+    subroutine t_outer_print(outer)
+        class(t_outer), intent(in) :: outer
+
+        write(*,*) "value:", outer%value, " inner value:", outer%inner%value
+    end subroutine t_outer_print
+
+    function get_outer_inner(outer) result(inner)
+        type(t_outer), intent(in) :: outer
+        type(t_inner) :: inner
+
+        inner = outer%inner
+    end function get_outer_inner
+
+end module dta_ct

--- a/examples/issue258_derived_type_attributes/dta_tc.f90
+++ b/examples/issue258_derived_type_attributes/dta_tc.f90
@@ -1,0 +1,54 @@
+module dta_tc
+    implicit none
+    
+    type :: t_inner
+        integer :: value
+        contains
+        procedure :: print => t_inner_print
+    end type t_inner
+
+    type :: t_outer
+        integer :: value
+        type(t_inner) :: inner
+    end type t_outer
+
+    interface t_inner
+        module procedure new_inner
+    end interface t_inner
+
+    interface t_outer
+        module procedure new_outer
+    end interface t_outer
+
+    contains
+
+    function new_inner(value) result(inner)
+        type(t_inner) :: inner
+        integer, intent(in) :: value
+
+        inner%value = value
+    end function new_inner
+
+    function new_outer(value, inner) result(node)
+        type(t_outer) :: node
+        integer, intent(in) :: value
+        type(t_inner), intent(in) :: inner
+
+        node%inner = inner
+        node%value = value
+    end function new_outer
+
+    subroutine t_inner_print(inner)
+        class(t_inner), intent(in) :: inner
+
+        write(*,*) "value:", inner%value
+    end subroutine t_inner_print
+
+    function get_outer_inner(outer) result(inner)
+        type(t_outer), intent(in) :: outer
+        type(t_inner) :: inner
+
+        inner = outer%inner
+    end function get_outer_inner
+
+end module dta_tc

--- a/examples/issue258_derived_type_attributes/dta_tt.f90
+++ b/examples/issue258_derived_type_attributes/dta_tt.f90
@@ -1,0 +1,46 @@
+module dta_tt
+    implicit none
+
+    type :: t_inner
+        integer :: value
+    end type t_inner
+
+    type :: t_outer
+        integer :: value
+        type(t_inner) :: inner
+    end type t_outer
+
+    interface t_inner
+        module procedure new_inner
+    end interface t_inner
+
+    interface t_outer
+        module procedure new_outer
+    end interface t_outer
+
+    contains
+
+    function new_inner(value) result(inner)
+        type(t_inner) :: inner
+        integer, intent(in) :: value
+
+        inner%value = value
+    end function new_inner
+
+    function new_outer(value, inner) result(node)
+        type(t_outer) :: node
+        integer, intent(in) :: value
+        type(t_inner), intent(in) :: inner
+
+        node%inner = inner
+        node%value = value
+    end function new_outer
+
+    function get_outer_inner(outer) result(inner)
+        type(t_outer), intent(in) :: outer
+        type(t_inner) :: inner
+
+        inner = outer%inner
+    end function get_outer_inner
+
+end module dta_tt

--- a/examples/issue258_derived_type_attributes/test.py
+++ b/examples/issue258_derived_type_attributes/test.py
@@ -1,0 +1,32 @@
+"""Test derived type as attributes of other derived types.
+
+Check all combinations of type / class (polymorphic derived type) for the outer and intner derived types."""
+import dta_tt
+import dta_ct
+import dta_tc
+import dta_cc
+
+for mod, o, i in [
+    (dta_tt.dta_tt, "t", "t"),
+    (dta_ct.dta_ct, "c", "t"),
+    (dta_tc.dta_tc, "t", "c"),
+    (dta_cc.dta_cc, "c", "c"),
+]:
+    print("Testing module:", mod)
+    inner1 = mod.t_inner(1)
+    assert inner1.value == 1
+    inner2 = mod.t_inner(2)
+    assert inner2.value == 2
+    if i == "c":
+        inner1.print()
+        inner2.print()
+
+    outer = mod.t_outer(10, inner1)
+    assert outer.value == 10
+    assert outer.inner.value == 1
+
+    outer.inner = inner2
+    assert outer.inner.value == 2
+    if o == "c":
+        outer.print()
+

--- a/f90wrap/f90wrapgen.py
+++ b/f90wrap/f90wrapgen.py
@@ -1085,14 +1085,16 @@ end type %(typename)s%(suffix)s"""
                 self.write("this_ptr = transfer(this, this_ptr)")
             if getset == "get":
                 if isinstance(t, ft.Type):
-                    if (self.is_class(t.orig_name)):
-                        self.write(
-                            "%s_ptr%%p => this_ptr%%p%%obj%%%s" % (el.orig_name, el.orig_name)
-                        )
+                    if (self.is_class(el.type)):
+                        self.write("allocate(%s_ptr%%p)" % el.orig_name)
+                        source = "%s_ptr%%p%%obj =" % el.orig_name
                     else:
-                        self.write(
-                            "%s_ptr%%p => this_ptr%%p%%%s" % (el.orig_name, el.orig_name)
-                        )
+                        source = "%s_ptr%%p =>" % el.orig_name
+                    if (self.is_class(t.orig_name)):
+                        target = "this_ptr%%p%%obj%%%s" % el.orig_name
+                    else:
+                        target = "this_ptr%%p%%%s" % el.orig_name
+                    self.write("%s %s" % (source, target))
                 else:
                     self.write(
                         "%s_ptr%%p => %s_%s" % (el.orig_name, t.name, el.orig_name)
@@ -1106,14 +1108,16 @@ end type %(typename)s%(suffix)s"""
                     % (el.orig_name, localvar, el.orig_name)
                 )
                 if isinstance(t, ft.Type):
-                    if (self.is_class(t.orig_name)):
-                        self.write(
-                            "this_ptr%%p%%obj%%%s = %s_ptr%%p" % (el.orig_name, el.orig_name)
-                        )
+                    if (self.is_class(el.type)):
+                        target = "%s_ptr%%p%%obj" % el.orig_name
                     else:
-                        self.write(
-                            "this_ptr%%p%%%s = %s_ptr%%p" % (el.orig_name, el.orig_name)
-                        )
+                        log.warning("oh no")
+                        target = "%s_ptr%%p" % el.orig_name
+                    if (self.is_class(t.orig_name)):
+                        source = "this_ptr%%p%%obj%%%s" % el.orig_name
+                    else:
+                        source = "this_ptr%%p%%%s" % el.orig_name
+                    self.write("%s = %s" % (source, target))
                 else:
                     self.write(
                         "%s_%s = %s_ptr%%p" % (t.name, el.orig_name, el.orig_name)


### PR DESCRIPTION
This PR fixes issue #258 by extending the generation of derived type getter functions with the additional `wrapper_type` layer which is also used for polymorphic derived types as return values.

Please let me know if anything needs to be changed or improved.

Thanks for the great package!