### PR TITLE
Fix handling of Fortran string arrays with explicit shape

### DIFF
--- a/examples/optional_string/main.f90
+++ b/examples/optional_string/main.f90
@@ -4,6 +4,7 @@ module m_string_test
   private
   public :: string_in
   public :: string_in_array
+  public :: string_in_array_hardcoded_size
   public :: string_to_string
   public :: string_to_string_array
   public :: string_out
@@ -18,6 +19,19 @@ contains
 
   subroutine string_in_array(input)
     character(len=6), intent(in) :: input(:)
+    integer :: i
+
+    if (input(1).ne."one   ") then
+      call f90wrap_abort("First char input is incorrect, should be 'one', but is '" // input(1) // "'" )
+    endif
+
+    if (input(2).ne."two   ") then
+      call f90wrap_abort("Second char input is incorrect, should be 'two', but is '" // input(2) // "'" )
+    endif
+  end subroutine
+
+  subroutine string_in_array_hardcoded_size(input)
+    character(len=6), intent(in) :: input(2)
     integer :: i
 
     if (input(1).ne."one   ") then
@@ -61,4 +75,3 @@ contains
   end subroutine
 
 end module m_string_test
-

--- a/examples/optional_string/test.py
+++ b/examples/optional_string/test.py
@@ -53,6 +53,11 @@ class TestTypeCheck(unittest.TestCase):
         with self.assertRaises((RuntimeError, UnicodeDecodeError)) as context:
           m_string_test.string_in_array(in_array)
 
+    @unittest.skipIf(version.parse(np.version.version) < version.parse("1.24.0") , "This test is known to fail on numpy version older than 1.24.0")
+    def test_string_in_array_hardcoded_size(self):
+        in_array = np.array(['one   ', 'two   '], dtype='S6')
+        m_string_test.string_in_array_hardcoded_size(in_array)
+
     def test_string_to_string(self):
         in_string = 'yo'
         out_string = m_string_test.string_to_string(in_string)

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -1139,12 +1139,9 @@ return %(el_name)s"""
                     self.indent()
                     self.write("{0} = {0}.astype('{1}')".format(arg.py_name, pytype))
                     self.dedent()
-                if ft_array_dim == -1:
-                    self.write(
-                        "if {0}.dtype.num != {1}:".format(arg.py_name, array_type)
-                    )
+
                 # Allow fortran character to match python ubyte, unicode_ or string_
-                elif array_type == np.ubyte().dtype.num:
+                if array_type == np.ubyte().dtype.num:
                     str_types = {
                         np.ubyte().dtype.num,
                         np.bytes_().dtype.num,
@@ -1160,10 +1157,21 @@ return %(el_name)s"""
                             ft_array_dim,
                         }
                     str_dims = {str(num) for num in str_dims}
-                    self.write(
-                        "if {0}.ndim not in {{{1}}} or {0}.dtype.num not in {{{2}}}:".format(
-                            arg.py_name, ",".join(str_dims), ",".join(str_types)
+                    if ft_array_dim == -1:
+                        self.write(
+                            "if {0}.dtype.num not in {{{1}}}:".format(
+                                arg.py_name, ",".join(str_types)
+                            )
                         )
+                    else:
+                        self.write(
+                            "if {0}.ndim not in {{{1}}} or {0}.dtype.num not in {{{2}}}:".format(
+                                arg.py_name, ",".join(str_dims), ",".join(str_types)
+                            )
+                        )
+                elif ft_array_dim == -1:
+                    self.write(
+                        "if {0}.dtype.num != {1}:".format(arg.py_name, array_type)
                     )
                 else:
                     self.write(


### PR DESCRIPTION
This fixes a bug in the type-checking feature that returned an error when character length was specified.
`TypeError: Expecting 'str' (code '2') with dim '-1' but got '|S6' (code '18') with dim '1'`