### PR TITLE
Enable to parse multiline comments

### DIFF
--- a/examples/docstring/docstring_test.py
+++ b/examples/docstring/docstring_test.py
@@ -13,6 +13,7 @@ def clean_str(in_str):
   for i,line in enumerate(docstring_lines):
     docstring_lines[i] = line.strip(' \n\t')
     docstring_lines[i] = re.sub('Defined at main\\.f90 lines \\d+-\\d+', '', docstring_lines[i])
+    docstring_lines[i] = re.sub(' +', ' ', docstring_lines[i])
   return '\n'.join(docstring_lines)
 
 class TestDocstring(unittest.TestCase):
@@ -159,6 +160,93 @@ class TestDocstring(unittest.TestCase):
     Those are very informative details
 
     details_doc(self, radius)
+    Defined at main.f90 lines 80-82
+
+    Parameters
+    ----------
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
+    """
+
+    assert clean_str(ref_docstring) == clean_str(docstring)
+
+  def test_details_with_parenthesis(self):
+    circle = m_circle.t_circle()
+    docstring = m_circle.details_with_parenthesis.__doc__
+    ref_docstring = """
+    Initialize circle
+
+    Those are very informative details (with parenthesis)
+
+    details_with_parenthesis(self, radius)
+    Defined at main.f90 lines 80-82
+
+    Parameters
+    ----------
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
+    """
+
+    assert clean_str(ref_docstring) == clean_str(docstring)
+
+  def test_multiline_details(self):
+    circle = m_circle.t_circle()
+    docstring = m_circle.multiline_details.__doc__
+    ref_docstring = """
+    Initialize circle
+
+    First details line
+    Second details line
+
+    multiline_details(self, radius)
+    Defined at main.f90 lines 80-82
+
+    Parameters
+    ----------
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
+    """
+
+    assert clean_str(ref_docstring) == clean_str(docstring)
+
+  def test_empty_lines_details(self):
+    circle = m_circle.t_circle()
+    docstring = m_circle.empty_lines_details.__doc__
+    ref_docstring = """
+    Initialize circle
+
+    First details line
+
+    Second details line after a empty line
+
+    empty_lines_details(self, radius)
+    Defined at main.f90 lines 80-82
+
+    Parameters
+    ----------
+    circle : T_Circle
+        t_circle to initialize [in,out]
+    radius : float32
+        radius of the circle [in]
+    """
+
+    assert clean_str(ref_docstring) == clean_str(docstring)
+
+  def test_long_line_brief(self):
+    circle = m_circle.t_circle()
+    docstring = m_circle.long_line_brief.__doc__
+    ref_docstring = """
+    This is a very long brief that takes up a lot of space and contains lots of information, it should probably be wrapped to the next line, but we will continue regardless
+
+    Those are very informative details
+
+    long_line_brief(self, radius)
     Defined at main.f90 lines 80-82
 
     Parameters

--- a/examples/docstring/main.f90
+++ b/examples/docstring/main.f90
@@ -15,7 +15,10 @@ module m_circle
   public :: construct_circle,construct_circle_more_doc
   public :: incomplete_doc_sub
   public :: no_direction,doc_inside
-  public :: output_1,function_2,details_doc
+  public :: output_1,function_2
+  public :: details_doc,details_with_parenthesis
+  public :: multiline_details,empty_lines_details,long_line_brief
+
 
 contains
 
@@ -114,6 +117,55 @@ contains
     real, intent(in) :: radius
   end subroutine details_doc
 
+    !===========================================================================
+    !>
+    !! \brief Initialize circle
+    !! \details Those are very informative details (with parenthesis)
+    !! \param[in,out] circle      t_circle to initialize
+    !! \param[in]     radius      radius of the circle
+    !<
+  subroutine details_with_parenthesis(circle,radius)
+    type(t_circle) :: circle
+    real, intent(in) :: radius
+  end subroutine details_with_parenthesis
+
+    !===========================================================================
+    !>
+    !! \brief Initialize circle
+    !! \details First details line
+    !!        Second details line
+    !! \param[in,out] circle      t_circle to initialize
+    !! \param[in]     radius      radius of the circle
+    !<
+  subroutine multiline_details(circle,radius)
+    type(t_circle) :: circle
+    real, intent(in) :: radius
+  end subroutine multiline_details
+
+    !===========================================================================
+    !>
+    !! \brief Initialize circle
+    !! \details First details line
+    !!
+    !!        Second details line after a empty line
+    !! \param[in,out] circle      t_circle to initialize
+    !! \param[in]     radius      radius of the circle
+    !<
+  subroutine empty_lines_details(circle,radius)
+    type(t_circle) :: circle
+    real, intent(in) :: radius
+  end subroutine empty_lines_details
+
+    !===========================================================================
+    !>
+    !! \brief This is a very long brief that takes up a lot of space and contains lots of information, it should probably be wrapped to the next line, but we will continue regardless
+    !! \details Those are very informative details
+    !! \param[in,out] circle      t_circle to initialize
+    !! \param[in]     radius      radius of the circle
+    !<
+  subroutine long_line_brief(circle,radius)
+    type(t_circle) :: circle
+    real, intent(in) :: radius
+  end subroutine long_line_brief
+
 end module m_circle
-
-


### PR DESCRIPTION
Multiline comments were not parsed correctly, which breaks the feature that rewrites Fortran comments as Python docstrings.  
This PR updates the parser to support multiline comments and adds corresponding tests.