### PR TITLE
feat: add --return-bool flag to return Python bools

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -45,6 +45,7 @@ list(APPEND tests
 	  dump_package
     method_optional
     relative_import
+    return_bool
 )
 
 foreach(test ${tests})

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,7 +40,8 @@ EXAMPLES = arrayderivedtypes \
 	auto_raise_error \
 	dump_package \
 	method_optional \
-	relative_import
+	relative_import \
+	return_bool
 
 PYTHON = python
 

--- a/examples/return_bool/Makefile
+++ b/examples/return_bool/Makefile
@@ -1,0 +1,32 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+include ../make.inc
+
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v --return-bool
+F2PY        = f2py-f90wrap
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+main.o: ${F90_SRC}
+	${F90} ${F90FLAGS} -c $< -o $@
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+f2py: ${F90WRAP_SRC}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 *.o
+
+test: f2py
+	${PYTHON} tests.py

--- a/examples/return_bool/Makefile.meson
+++ b/examples/return_bool/Makefile.meson
@@ -1,0 +1,7 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+WRAPFLAGS += --return-bool
+
+test: build
+	$(PYTHON) tests.py

--- a/examples/return_bool/main.f90
+++ b/examples/return_bool/main.f90
@@ -1,0 +1,16 @@
+module m_test
+  implicit none
+  private
+
+  public :: return_logical
+
+contains
+
+  logical function return_logical(flag)
+    logical, intent(in)  :: flag
+
+    return_logical = flag
+
+  end function return_logical
+
+end module m_test

--- a/examples/return_bool/tests.py
+++ b/examples/return_bool/tests.py
@@ -1,0 +1,15 @@
+import unittest
+
+from pywrapper import m_test
+
+class TestReturnBool(unittest.TestCase):
+
+    def test_return_logical(self):
+        assert(m_test.return_logical(True) == True)
+        assert(isinstance(m_test.return_logical(True), bool))
+        assert(m_test.return_logical(False) == False)
+        assert(isinstance(m_test.return_logical(False), bool))
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/examples/type_check/kind.map
+++ b/examples/type_check/kind.map
@@ -1,4 +1,5 @@
 {\
 'integer':{'1':'signed_char', '2':'short', '4':'int', '8':'long_long'},\
 'real':{'4':'float', '8':'double'},\
+'logical':{'': 'bool'},\
 }

--- a/f90wrap/fortran.py
+++ b/f90wrap/fortran.py
@@ -1009,6 +1009,7 @@ def f2numpy_type(typename, kind_map):
         'complex_double' : 'complex128',
         'complex_long_double' : 'complex256',
         'string' : 'str',
+        'bool' : 'bool',
     }
 
     if c_type not in c_type_to_numpy_type:

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -60,7 +60,9 @@ class PythonWrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
             max_length=None,
             auto_raise=None,
             type_check=False,
-            relative=False):
+            relative=False,
+            return_bool=False,
+            ):
         if max_length is None:
             max_length = 80
         cg.CodeGenerator.__init__(
@@ -83,6 +85,7 @@ class PythonWrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
         self.init_file = init_file
         self.type_check = type_check
         self.relative = relative
+        self.return_bool = return_bool
         try:
             self._err_num_var, self._err_msg_var = auto_raise.split(',')
         except ValueError:
@@ -595,7 +598,14 @@ except ValueError:
                             "%s = %s.from_handle(%s, alloc=True)"
                             % (ret_val.name, cls_name, ret_val.name)
                         )
-                self.write("return %(result)s" % dct)
+                    # convert back Fortran logical to Python bool
+                    if self.return_bool and ret_val.type == "logical":
+                        dct["result"] = dct["result"].replace(
+                            ret_val.name, 'bool(%s)' % ret_val.name
+                        )
+
+                if dct["result"]:
+                    self.write("return %(result)s" % dct)
 
             self.dedent()
             self.write()

--- a/f90wrap/scripts/main.py
+++ b/f90wrap/scripts/main.py
@@ -169,6 +169,8 @@ USAGE
                             help="List of json files listing modules/types coming from external f90wrap")
         parser.add_argument('--dump-package', default="",
                             help="Output json file where to dump package description, can be reused in another package later via --external-packages option")
+        parser.add_argument('--return-bool', action='store_true', default=False,
+                            help="Python functions return bool (instead of integer) when associated Fortran type is a logical")
 
         args = parser.parse_args()
 
@@ -402,8 +404,8 @@ USAGE
                                       max_length=py_max_line_length,
                                       auto_raise=auto_raise_error,
                                       type_check=type_check,
-                                      relative = relative,
-                                      ).visit(py_tree)
+                                      relative=relative,
+                                      return_bool=return_bool).visit(py_tree)
         fwrap.F90WrapperGenerator(prefix, fsize, string_lengths,
                                   abort_func, kind_map, types, default_to_inout,
                                   max_length=f90_max_line_length,


### PR DESCRIPTION
This PR adds the `return-bool` flag.
When a wrapped Fortran function returns a `logical`, the Python wrapper gets an int representing the boolean.
This comes from the fact that C does not have an actual bool type.
When this flag is enabled, the Python wrapper will cast return values that were declared as `logical` in the Fortran wrapped code from Python `int` to Python `bool`.
The default behaviour, `return-bool` flag set to False, is the same as the current one.