### PR TITLE
ci: replace retired macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]
-        - [macos-13, macosx, x86_64]
+        - [macos-15-intel, macosx, x86_64]
         - [windows-latest, win, AMD64]
         - [macos-14, macosx, arm64]
 


### PR DESCRIPTION
## Summary

- Replace `macos-13` with `macos-15-intel` in the wheel building workflow
- The macos-13 runner was deprecated Sept 22, 2025 and will be fully retired by Dec 4-8, 2025
- The `macos-15-intel` runner is GitHub's official replacement for Intel x86_64 macOS builds (available until Aug 2027)

## Test plan

- [ ] Verify the `macos-15-intel` wheel build jobs complete successfully
- [ ] Check that x86_64 macOS wheels are properly built for all Python versions (cp39, cp310, cp311, cp312, cp313)
- [ ] Confirm test commands (`make test_meson`) pass on the new runner

## References

- [GitHub Changelog: macOS 13 closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [actions/runner-images #13045: macos-15-intel availability](https://github.com/actions/runner-images/issues/13045)

🤖 Generated with [Claude Code](https://claude.com/claude-code)