### PR TITLE
Fix fallback finalizer pattern: _initialise -> _finalise

### DIFF
--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -485,7 +485,11 @@ except ValueError:
 
         destructor_proc = self._destructor_proc_for(node)
         fallback_call = "%(mod_name)s.%(subroutine_name)s" % dct
-        fallback_call = fallback_call.replace("__initialise", "__finalise")
+        # Replace _initialise with _finalise for fallback finalizer
+        # Note: use single underscore pattern, not double, because subroutine names
+        # like "f90wrap_module__type_initialise" have __ between module and type,
+        # but only _ between type and "initialise"
+        fallback_call = fallback_call.replace("_initialise", "_finalise")
         destructor_helper = None
         destructor_args = None
 


### PR DESCRIPTION
## Summary

The fallback finalizer code was replacing `"__initialise"` with `"__finalise"`, but the actual subroutine name pattern uses single underscore before "initialise".

For example, the subroutine name:
```
f90wrap_descriptors_module__descriptor_initialise
```

Has `__` between module and type name, but only `_` before "initialise".

## Problem

This caused the replacement to never match, resulting in finalizers calling the initialise function instead of finalise. When garbage collection runs, the handle (an integer array) was passed to the initialise function which expects a string `args_str` parameter, causing errors like:

```
RuntimeError: Traceback (most recent call last)
  File "../src/GAP/descriptors.F90", line 730 kind unspecified
    descriptor_initialise found 0 IP Model types args_str='<garbage>'
```

## Fix

Change the pattern from `"__initialise"` to `"_initialise"` so it correctly matches and replaces with `"_finalise"`.

## Testing

This fix was tested with QUIP/quippy where the bug was originally reported. After the fix, descriptor objects can be created and garbage collected without errors.

Related QUIP commit: https://github.com/libAtoms/QUIP/commit/269d0f87b