### PR TITLE
Fix issue #171: Add value attribute to parser regex patterns

### DIFF
--- a/f90wrap/parser.py
+++ b/f90wrap/parser.py
@@ -70,7 +70,7 @@ submodule = re.compile(r'^submodule', re.IGNORECASE)
 program = re.compile(r'^program', re.IGNORECASE)
 program_end = re.compile(r'^end\s*program|end$', re.IGNORECASE)
 
-attribs = r'allocatable|pointer|save|contiguous|dimension *\(.*?\)|parameter|target|public|private|abstract|extends *\(.*?\)|bind\(C\)'  # jrk33 added target
+attribs = r'allocatable|pointer|save|contiguous|dimension *\(.*?\)|parameter|target|public|private|abstract|extends *\(.*?\)|bind\(C\)|value'  # jrk33 added target, value added for issue #171
 
 type_re = re.compile(r'^type((,\s*(' + attribs + r')\s*)*)(::)?\s*(?!\()', re.IGNORECASE)
 type_end = re.compile(r'^end\s*type|end$', re.IGNORECASE)
@@ -79,7 +79,7 @@ dummy_types_re = re.compile(r'recursive|pure|elemental', re.IGNORECASE)
 
 prefixes = r'elemental|impure|module|non_recursive|pure|recursive'
 types = r'double precision|(real\s*(\(.*?\))?)|(complex\s*(\(.*?\))?)|(integer\s*(\(.*?\))?)|(logical)|(character\s*(\(.*?\))?)|(type\s*\().*?(\))|(class\s*\().*?(\))'
-a_attribs = r'allocatable|pointer|save|dimension\(.*?\)|intent\(.*?\)|optional|target|public|private|contiguous'
+a_attribs = r'allocatable|pointer|save|dimension\(.*?\)|intent\(.*?\)|optional|target|public|private|contiguous|value'
 
 types_re = re.compile(types, re.IGNORECASE)
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,9 +1,51 @@
 import unittest
+import tempfile
+import os
 from f90wrap import parser
 from . import test_samples_dir
 
 
 class TestParser(unittest.TestCase):
+
+    def test_value_attribute_parsing(self):
+        '''
+        Verify that the value attribute is correctly parsed and types are preserved.
+        This is a regression test for issue #171.
+        '''
+        fortran_code = '''
+module test_mod
+    implicit none
+contains
+    subroutine foo(a, some_var, another_var)
+        integer, value, intent(in) :: a
+        integer, value :: some_var
+        integer, intent(in) :: another_var
+    end subroutine foo
+end module test_mod
+'''
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.f90', delete=False) as f:
+            f.write(fortran_code)
+            temp_path = f.name
+
+        try:
+            root = parser.read_files([temp_path])
+            proc = root.modules[0].procedures[0]
+
+            # All arguments should be integer, not real
+            self.assertEqual(proc.arguments[0].type, 'integer')
+            self.assertEqual(proc.arguments[1].type, 'integer')
+            self.assertEqual(proc.arguments[2].type, 'integer')
+
+            # value attribute should be preserved
+            self.assertIn('value', proc.arguments[0].attributes)
+            self.assertIn('value', proc.arguments[1].attributes)
+            self.assertNotIn('value', proc.arguments[2].attributes)
+
+            # intent should be preserved
+            self.assertIn('intent(in)', proc.arguments[0].attributes)
+            self.assertIn('intent(in)', proc.arguments[2].attributes)
+        finally:
+            os.unlink(temp_path)
 
     def test_parse_type_procedures(self):
         root = parser.read_files([str(test_samples_dir/'circle.f90')])


### PR DESCRIPTION
## Summary

- Fixes issue #171 where `integer, value` arguments were incorrectly parsed as `real` type
- The parser's regex patterns for attributes (`attribs` and `a_attribs`) did not include the Fortran `value` attribute
- Added `value` to both attribute patterns in `parser.py`

## Test plan
- [x] Added `test_value_attribute_parsing` test in `test/test_parser.py`
- [x] Test verifies that `integer, value, intent(in)` arguments retain `integer` type and `value` attribute

Closes #171
