### PR TITLE
Fix issue #222: Validate cached arrays to prevent stale handle collisions

### DIFF
--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -1230,9 +1230,13 @@ return %(el_name)s"""
             """array_ndim, array_type, array_shape, array_handle = \
     %(mod_name)s.%(subroutine_name)s(%(handle)s)
 array_hash = hash((array_ndim, array_type, tuple(array_shape), array_handle))
-if array_hash in %(selfdot)s_arrays:
-    %(el_name)s = %(selfdot)s_arrays[array_hash]
-else:
+%(el_name)s = %(selfdot)s_arrays.get(array_hash)
+if %(el_name)s is not None:
+    # Validate cached array: check data pointer matches current handle (issue #222)
+    # Arrays can be deallocated and reallocated at same address, invalidating cache
+    if %(el_name)s.ctypes.data != array_handle:
+        %(el_name)s = None
+if %(el_name)s is None:
     try:
         %(el_name)s = f90wrap.runtime.get_array(f90wrap.runtime.sizeof_fortran_t,
                                 %(handle)s,


### PR DESCRIPTION
## Summary
- Fixes intermittent CI failures caused by stale array cache entries (issue #222)
- When Fortran arrays are deallocated and reallocated, they may reuse the same memory address
- The Python-side cache uses memory handles as keys, which caused stale arrays to be returned
- Added validation: when retrieving from cache, verify the NumPy array's `ctypes.data` pointer matches the current Fortran handle
- If mismatch detected, the cache entry is invalidated and a fresh array is created

## Changes
- Modified `f90wrap/pywrapgen.py`: Added cache validation check before returning cached arrays

## Test plan
- [x] Addresses intermittent CI failures where incorrect data was returned after array reallocation
- [x] Cache still provides performance benefits for stable arrays

Closes #222