### PR TITLE
add missing examples to tests

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,15 +9,22 @@ list(APPEND tests
     arrays_fixed
     arrays_in_derived_types_issue50
     auto_raise_error
+    callback_print_function_issue93
     class_names
     cylinder
     decoded_strings
+    default_i8
+    derived-type-aliases
     derivedtypes
+    derivedtypes_procedure
     docstring
     dump_package
     elemental
+    errorbinding
     example2
     extends
+    f2py_string_input
+    fixed_1D_derived_type_array_argument
     fortran_oo
     intent_out_size
     interface
@@ -27,27 +34,38 @@ list(APPEND tests
     issue235_allocatable_classes
     issue254_getter
     issue258_derived_type_attributes
+    issue261_array_shapes
     issue297_ignored_abstract_classes
+    issue299_directc_nested_functions
+    issue301_complex_types
+    issue302_pointer_warning
     issue305_multiple_abstract_interfaces
     issue307_logical_array
     issue32
+    issue41_abstract_classes
     keep_single_interface
+    keyword_renaming_issue160
     kind_map_default
     long_subroutine_name
     method_optional
     mockderivetype
     mod_arg_clash
+    name_collision
     optional_args_issue53
     optional_derived_arrays
     optional_string
     output_kind
     passbyreference
+    recursive_type
+    recursive_type_array
     relative_import
     remove_pointer_arg
     return_array
     return_bool
+    signature_vs_backend
     string_array_input_f2py
     strings
+    subroutine_args
     subroutine_contains_issue101
     type_bn
     type_check

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,20 +1,27 @@
 include make.inc
 
 EXAMPLES = \
-	arrayderivedtypes \
+    arrayderivedtypes \
     arrays \
     arrays_fixed \
     arrays_in_derived_types_issue50 \
     auto_raise_error \
+    callback_print_function_issue93 \
     class_names \
     cylinder \
     decoded_strings \
+    default_i8 \
+    derived-type-aliases \
     derivedtypes \
+    derivedtypes_procedure \
     docstring \
     dump_package \
     elemental \
+    errorbinding \
     example2 \
     extends \
+    f2py_string_input \
+    fixed_1D_derived_type_array_argument \
     fortran_oo \
     intent_out_size \
     interface \
@@ -24,27 +31,38 @@ EXAMPLES = \
     issue235_allocatable_classes \
     issue254_getter \
     issue258_derived_type_attributes \
+    issue261_array_shapes \
     issue297_ignored_abstract_classes \
+    issue299_directc_nested_functions \
+    issue301_complex_types \
+    issue302_pointer_warning \
     issue305_multiple_abstract_interfaces \
     issue307_logical_array \
     issue32 \
+    issue41_abstract_classes \
     keep_single_interface \
+    keyword_renaming_issue160 \
     kind_map_default \
     long_subroutine_name \
     method_optional \
     mockderivetype \
     mod_arg_clash \
+    name_collision \
     optional_args_issue53 \
     optional_derived_arrays \
     optional_string \
     output_kind \
     passbyreference \
+    recursive_type \
+    recursive_type_array \
     relative_import \
     remove_pointer_arg \
     return_array \
     return_bool \
+    signature_vs_backend \
     string_array_input_f2py \
     strings \
+    subroutine_args \
     subroutine_contains_issue101 \
     type_bn \
     type_check


### PR DESCRIPTION
As discussed in #308, some of the examples are not tested. I.e. they are not included in `CmakeLists.txt` & `Makefile`. This PR sorts and adds all available examples into the list.

---

Newly added tests:

- [ ] `callback_print_function_issue93` - `undefined symbol: pyfunc_print_`
- [ ] `default_i8` - `Segmentation fault`
- [x] `derived-type-aliases`
- [x] `derivedtypes_procedure`
- [x] `errorbinding`
- [x] `f2py_string_input` - `No rule to make target 'Makefile.meson'`
- [x] `fixed_1D_derived_type_array_argument`
- [x] `issue261_array_shapes` - `No rule to make target 'Makefile.meson'`
- [x] `issue299_directc_nested_functions` - `No rule to make target 'Makefile.meson'`
- [x] `issue301_complex_types` - `No rule to make target 'Makefile.meson'`
- [x] `issue302_pointer_warning` - `No rule to make target 'Makefile.meson'`
- [ ] `issue41_abstract_classes` - `AttributeError: 'myclass_t' object has no attribute 'get_value'`
- [x] `keyword_renaming_issue160`
- [x] `name_collision`
- [ ] `recursive_type` - `Error: Derived type ‘node’ at (1) has not been declared`
- [x] `recursive_type_array`
- [x] `signature_vs_backend`
- [x] `subroutine_args`

`quip_regression` was not added to the tests as it has it's own workflow.