### PR TITLE
fix: handle Prototype objects in direct-c mode

### DIFF
--- a/examples/directc_prototype/Makefile
+++ b/examples/directc_prototype/Makefile
@@ -1,0 +1,13 @@
+# Test case for direct-c mode with interface prototypes
+# This tests the fix for GitHub issue #358
+
+all: test
+
+test:
+	f90wrap -m test_prototype --direct-c test_module.f90
+	@echo "Success: direct-c mode handles interface prototypes correctly"
+
+clean:
+	rm -f f90wrap_*.f90 *.c *.py .f2py_f2cmap
+
+.PHONY: all test clean

--- a/examples/directc_prototype/test_module.f90
+++ b/examples/directc_prototype/test_module.f90
@@ -1,0 +1,23 @@
+module test_interface_prototype
+    implicit none
+
+    interface generic_proc
+        module procedure proc_int
+        module procedure proc_real
+    end interface generic_proc
+
+contains
+
+    subroutine proc_int(x, result)
+        integer, intent(in) :: x
+        integer, intent(out) :: result
+        result = x * 2
+    end subroutine proc_int
+
+    subroutine proc_real(x, result)
+        real, intent(in) :: x
+        real, intent(out) :: result
+        result = x * 2.0
+    end subroutine proc_real
+
+end module test_interface_prototype

--- a/f90wrap/directc.py
+++ b/f90wrap/directc.py
@@ -122,7 +122,10 @@ def analyse_interop(tree: ft.Root, kind_map: Dict[str, Dict[str, str]]) -> Dict[
         except TypeError:
             return
         for proc in iterator:
-            key = ProcedureKey(proc.mod_name, getattr(proc, 'type_name', None), proc.name)
+            # Skip Prototype objects - they lack attributes/arguments needed for analysis
+            if isinstance(proc, ft.Prototype):
+                continue
+            key = ProcedureKey(getattr(proc, 'mod_name', None), getattr(proc, 'type_name', None), proc.name)
             classification[key] = InteropInfo(
                 requires_helper=_procedure_requires_helper(proc, kind_map)
             )

--- a/f90wrap/scripts/main.py
+++ b/f90wrap/scripts/main.py
@@ -519,21 +519,23 @@ USAGE
             # 2. module.interfaces[].procedures (generic interface procedures)
             # 3. type.procedures (type-bound procedures)
             # 4. tree.procedures (top-level procedures)
+            # Note: Prototype objects (interface declarations) are filtered out as they
+            # lack the attributes/arguments needed for code generation.
             all_procs = []
             for module in f90_tree.modules:
                 # Module-level procedures
-                all_procs.extend(module.procedures)
+                all_procs.extend(p for p in module.procedures if not isinstance(p, fortran.Prototype))
 
                 # Generic interface procedures (including module procedures wrapped in interfaces)
                 for iface in getattr(module, 'interfaces', []):
-                    all_procs.extend(getattr(iface, 'procedures', []))
+                    all_procs.extend(p for p in getattr(iface, 'procedures', []) if not isinstance(p, fortran.Prototype))
 
                 # Type-bound procedures
                 for derived in getattr(module, 'types', []):
-                    all_procs.extend(getattr(derived, 'procedures', []))
+                    all_procs.extend(p for p in getattr(derived, 'procedures', []) if not isinstance(p, fortran.Prototype))
 
             # Top-level procedures
-            all_procs.extend(getattr(f90_tree, 'procedures', []))
+            all_procs.extend(p for p in getattr(f90_tree, 'procedures', []) if not isinstance(p, fortran.Prototype))
 
             c_code = generator.generate_module(init_module_name, procedures=all_procs)
 


### PR DESCRIPTION
## Summary

- Fix AttributeError crash when using `--direct-c` with code containing generic interfaces
- Prototype objects (interface declarations) lack attributes like `mod_name`, `attributes`, and `arguments` needed for direct-c code generation

## Changes

- `directc.py`: Skip Prototype objects in `analyse_interop()` and use `getattr` for safer `mod_name` access
- `main.py`: Filter out Prototype objects when collecting procedures for direct-c code generation

## Test plan

- [x] Added test case in `examples/directc_prototype/` with a module containing generic interfaces
- [x] Tested with fortplot project (204 source files) - generates 196 wrapper files and 1 C file successfully

Fixes #358