### PR TITLE
Add explicit regression test for issue #363

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,6 +40,7 @@ EXAMPLES = \
 	issue307_logical_array \
 	issue32 \
 	issue353_selected_kind \
+	issue363_missing_only_import \
 	issue357_name_conflict \
 	issue41_abstract_classes \
 	keep_single_interface \

--- a/examples/issue363_missing_only_import/Makefile
+++ b/examples/issue363_missing_only_import/Makefile
@@ -1,0 +1,9 @@
+include ../make.meson.inc
+
+NAME := global_mod
+LIBSRC_WRAP_FPP_FILES := global_mod.f90
+
+test: build
+	$(PYTHON) run.py
+
+.PHONY: test

--- a/examples/issue363_missing_only_import/Makefile.meson
+++ b/examples/issue363_missing_only_import/Makefile.meson
@@ -1,0 +1,9 @@
+include ../make.meson.inc
+
+NAME := global_mod
+LIBSRC_WRAP_FPP_FILES := global_mod.f90
+
+test: build
+	$(PYTHON) run.py
+
+.PHONY: test

--- a/examples/issue363_missing_only_import/global_mod.f90
+++ b/examples/issue363_missing_only_import/global_mod.f90
@@ -1,0 +1,10 @@
+module global_mod
+  implicit none
+  integer :: number
+contains
+  subroutine print_number(number)
+    integer, intent(in) :: number
+
+    print *, number
+  end subroutine print_number
+end module global_mod

--- a/examples/issue363_missing_only_import/run.py
+++ b/examples/issue363_missing_only_import/run.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import global_mod
+
+
+def main():
+    wrapper = Path("f90wrap_global_mod.f90").read_text(encoding="utf-8")
+    expected = "use global_mod, only: print_number"
+    if expected not in wrapper:
+        raise SystemExit(
+            "Missing selective import in generated wrapper:\n"
+            f"{expected}\n\nGenerated wrapper:\n{wrapper}"
+        )
+
+    global_mod.global_mod.print_number(7)
+    print("Issue #363 test passed: generated wrapper uses selective import")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #363.

Current `master` already emits the selective `use ..., only:` import needed to avoid the name collision reported in #363, but there was no dedicated regression coverage for that exact case.

This PR adds an `issue363_missing_only_import` example that:
- reproduces a module-level variable / procedure-argument name collision
- asserts that the generated wrapper uses `use global_mod, only: print_number`
- runs through both the regular wrapper flow and the Direct-C Meson flow

## Verification

### Historical failure on v0.3.0
```sh
$ /tmp/f90wrap-v030-venv/bin/python -m f90wrap -m global_mod global_mod.f90
$ sed -n '1,8p' f90wrap_global_mod.f90
! Module global_mod defined in file global_mod.f90

subroutine f90wrap_global_mod__print_number(number)
    use global_mod
    implicit none
...
$ gfortran -c global_mod.f90
$ gfortran -c f90wrap_global_mod.f90
f90wrap_global_mod.f90:7:33:

    7 |     integer, intent(in) :: number
      |                                 1
Error: Name ‘number’ at (1) is an ambiguous reference to ‘number’ from current program unit
f90wrap_global_mod.f90:3:45:

    3 | subroutine f90wrap_global_mod__print_number(number)
      |                                             1~~~~~
Error: Symbol ‘number’ at (1) has no IMPLICIT type
```

### Current branch
```sh
$ cd examples/issue363_missing_only_import
$ PATH="/tmp/f90wrap-venv/bin:$PATH" PYTHON=/tmp/f90wrap-venv/bin/python make test
...
Issue #363 test passed: generated wrapper uses selective import

$ PATH="/tmp/f90wrap-venv/bin:$PATH" PYTHON=/tmp/f90wrap-venv/bin/python DIRECTC=yes make -f Makefile.meson test
...
Issue #363 test passed: generated wrapper uses selective import

$ cd /tmp/f90wrap-test-run
$ PATH="/tmp/f90wrap-venv/bin:$PATH" /tmp/f90wrap-venv/bin/python -m unittest test.test_directc
.............................
----------------------------------------------------------------------
Ran 29 tests in 0.014s

OK
```
