### PR TITLE
feat: support optional complex scalar arguments

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -41,6 +41,7 @@ EXAMPLES = \
 	issue32 \
 	issue353_selected_kind \
 	issue357_name_conflict \
+	issue371_optional_complex \
 	issue41_abstract_classes \
 	keep_single_interface \
 	keyword_renaming_issue160 \

--- a/examples/issue371_optional_complex/Makefile
+++ b/examples/issue371_optional_complex/Makefile
@@ -1,0 +1,33 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+
+include ../make.inc
+PY_MOD      = pywrapper
+F90_SRC     = main.f90
+OBJ         = $(F90_SRC:.f90=.o)
+F90WRAP_SRC = $(addprefix f90wrap_,${F90_SRC})
+WRAPFLAGS   = -v
+F2PY        = f2py-f90wrap
+SRC_AR      = libsrc.a
+.PHONY: all clean
+
+all: test
+
+clean:
+	rm -rf *.mod *.smod *.o ${SRC_AR} f90wrap*.f90 ${PY_MOD}.py _${PY_MOD}*.so __pycache__/ .f2py_f2cmap build ${PY_MOD}/
+
+%.o: %.f90
+	${F90} ${F90FLAGS} -c $< -o $@
+
+${F90WRAP_SRC}: ${OBJ}
+	${F90WRAP} -m ${PY_MOD} ${WRAPFLAGS} ${F90_SRC}
+
+${SRC_AR}: ${OBJ}
+	ar rcs $@ ${OBJ}
+
+f2py: ${F90WRAP_SRC} ${SRC_AR}
+	CFLAGS="${CFLAGS}" ${F2PY} -c -m _${PY_MOD} ${F2PYFLAGS} f90wrap_*.f90 -L. -lsrc
+
+test: f2py
+	${PYTHON} tests.py

--- a/examples/issue371_optional_complex/Makefile.meson
+++ b/examples/issue371_optional_complex/Makefile.meson
@@ -1,0 +1,6 @@
+include ../make.meson.inc
+
+NAME     := pywrapper
+
+test: build
+	$(PYTHON) tests.py

--- a/examples/issue371_optional_complex/main.f90
+++ b/examples/issue371_optional_complex/main.f90
@@ -1,0 +1,21 @@
+! Regression example for optional complex scalar arguments.
+!
+! f90wrap previously dropped every optional complex scalar argument in
+! transform.py, so present(z) could never be exercised from Python. Required
+! complex scalars were always supported. This passes a complex value through
+! present(z) on both the regular f2py path and the --direct-c path.
+module m_complex
+    implicit none
+contains
+
+    subroutine opt_complex(flag, z)
+        integer, intent(out) :: flag
+        complex, intent(in), optional :: z
+        if (present(z)) then
+            flag = nint(real(z)) + nint(aimag(z))
+        else
+            flag = -1
+        end if
+    end subroutine opt_complex
+
+end module m_complex

--- a/examples/issue371_optional_complex/tests.py
+++ b/examples/issue371_optional_complex/tests.py
@@ -1,0 +1,17 @@
+import unittest
+
+from pywrapper import m_complex
+
+
+class TestOptionalComplex(unittest.TestCase):
+    def test_present_single(self):
+        # Previously impossible: the optional complex argument was dropped
+        # entirely in transform.py before it reached either backend.
+        self.assertEqual(m_complex.opt_complex(z=complex(2, 3)), 5)
+
+    def test_present_negativeimag(self):
+        self.assertEqual(m_complex.opt_complex(z=complex(4, -1)), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/f90wrap/directc_cgen/arguments_scalar.py
+++ b/f90wrap/directc_cgen/arguments_scalar.py
@@ -68,6 +68,11 @@ def _write_scalar_number_handling(gen: 'DirectCGenerator', arg: ft.Argument, c_t
         gen.write(f"{arg.name}_val = ({c_type})PyFloat_AsDouble(py_{arg.name});")
     elif fmt == "p":
         gen.write(f"{arg.name}_val = ({c_type})PyObject_IsTrue(py_{arg.name});")
+    elif fmt == "D":
+        gen.write(f"Py_complex {arg.name}_pc = PyComplex_AsCComplex(py_{arg.name});")
+        gen.write(
+            f"{arg.name}_val = ({c_type})({arg.name}_pc.real + {arg.name}_pc.imag * _Complex_I);"
+        )
     else:
         gen.write(
             f'PyErr_SetString(PyExc_TypeError, "Unsupported argument {arg.name}");'

--- a/f90wrap/numpy_utils.py
+++ b/f90wrap/numpy_utils.py
@@ -37,6 +37,12 @@ def _normalize_fortran_type(ftype: str) -> Tuple[str, Optional[str], Dict[str, b
         if not kind_str:
             kind_str = "8"
 
+    if base == "double complex":
+        base = "complex"
+        modifiers["force_double"] = True
+        if not kind_str:
+            kind_str = "8"
+
     return base, kind_str, modifiers
 
 
@@ -103,7 +109,10 @@ def numpy_type_from_fortran(ftype: str, kind_map: Dict[str, Dict[str, str]]) -> 
                 return "NPY_CLONGDOUBLE"
             if bits >= 8:
                 return "NPY_CDOUBLE"
-        return "NPY_CDOUBLE"
+            return "NPY_COMPLEX64"
+        if force_double:
+            return "NPY_CDOUBLE"
+        return "NPY_COMPLEX64"
 
     elif base == "character":
         return "NPY_STRING"
@@ -172,7 +181,10 @@ def c_type_from_fortran(ftype: str, kind_map: Dict[str, Dict[str, str]]) -> str:
                 return "long double _Complex"
             if bits >= 8:
                 return "double _Complex"
-        return "double _Complex"
+            return "float _Complex"
+        if force_double:
+            return "double _Complex"
+        return "float _Complex"
 
     elif base == "character":
         return "char"

--- a/f90wrap/transform.py
+++ b/f90wrap/transform.py
@@ -332,11 +332,6 @@ class UnwrappablesRemover(ft.FortranTransformer):
 
         dims = [attrib for attrib in node.attributes if attrib.startswith('dimension')]
 
-        # remove optional complex scalar arguments
-        if node.type.startswith('complex') and len(dims) == 0:
-            log.warning('removing optional argument %s as it is a complex scalar' % node.name)
-            return None
-
         # remove optional derived types not in self.types
         typename = ft.derived_typename(node.type)
         if typename and typename not in self.types:

--- a/test/samples/optional_complex.f90
+++ b/test/samples/optional_complex.f90
@@ -1,0 +1,13 @@
+module optional_complex
+    implicit none
+contains
+    subroutine opt_complex(flag, z)
+        integer, intent(out) :: flag
+        complex, intent(in), optional :: z
+        if (present(z)) then
+            flag = nint(real(z)) + nint(aimag(z))
+        else
+            flag = -1
+        end if
+    end subroutine opt_complex
+end module optional_complex

--- a/test/test_directc.py
+++ b/test/test_directc.py
@@ -52,8 +52,14 @@ class TestNumpyUtils(unittest.TestCase):
         self.assertEqual(numpy_utils.numpy_type_from_fortran('logical', {}), 'NPY_INT32')
 
     def test_numpy_type_from_fortran_complex(self):
-        """Test complex type mapping to NumPy."""
-        self.assertEqual(numpy_utils.numpy_type_from_fortran('complex', {}), 'NPY_CDOUBLE')
+        """Test complex type mapping to NumPy.
+
+        Default complex is two default reals (single precision), so it maps to
+        NPY_COMPLEX64, mirroring real -> NPY_FLOAT32.
+        """
+        self.assertEqual(numpy_utils.numpy_type_from_fortran('complex', {}), 'NPY_COMPLEX64')
+        self.assertEqual(numpy_utils.numpy_type_from_fortran('complex(4)', {}), 'NPY_COMPLEX64')
+        self.assertEqual(numpy_utils.numpy_type_from_fortran('double complex', {}), 'NPY_CDOUBLE')
         self.assertEqual(
             numpy_utils.numpy_type_from_fortran('complex(dp)', self.kind_map),
             'NPY_COMPLEX128'
@@ -84,8 +90,14 @@ class TestNumpyUtils(unittest.TestCase):
         self.assertEqual(numpy_utils.c_type_from_fortran('logical', {}), 'int')
 
     def test_c_type_from_fortran_complex(self):
-        """Test complex type mapping to C."""
-        self.assertEqual(numpy_utils.c_type_from_fortran('complex', {}), 'double _Complex')
+        """Test complex type mapping to C.
+
+        Default complex is single precision (two default reals), so it maps to
+        float _Complex, mirroring real -> float.
+        """
+        self.assertEqual(numpy_utils.c_type_from_fortran('complex', {}), 'float _Complex')
+        self.assertEqual(numpy_utils.c_type_from_fortran('complex(4)', {}), 'float _Complex')
+        self.assertEqual(numpy_utils.c_type_from_fortran('double complex', {}), 'double _Complex')
         self.assertEqual(
             numpy_utils.c_type_from_fortran('complex(sp)', self.kind_map),
             'float _Complex'

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -107,6 +107,17 @@ class TestTransform(unittest.TestCase):
         # Same input should produce same output (deterministic)
         self.assertEqual(shorten_long_name(long_name), shortened)
 
+    def test_optional_complex_scalar_kept(self):
+        '''
+        Optional complex scalar arguments must not be dropped.
+        Regression test for issue #371.
+        '''
+        root = parser.read_files([str(test_samples_dir/'optional_complex.f90')])
+        root = transform.UnwrappablesRemover([], [], [], [], []).visit(root)
+
+        sub = next(p for p in root.modules[0].procedures if p.name == 'opt_complex')
+        self.assertIn('z', [arg.name for arg in sub.arguments])
+
     def test_kind_parameter_uses_clause(self):
         '''
         Verify that kind parameters used in procedure arguments are imported.


### PR DESCRIPTION
## Summary

Closes #371.

`UnwrappablesRemover.visit_Argument` dropped every optional complex scalar argument, so `present(z)` could never be exercised from Python. Required complex scalars were wrapped normally. This removes that restriction, after which the f2py path handles optional complex scalars directly.

For `--direct-c`, two further gaps are fixed so complex scalar values work:

- the scalar argument parser had no complex case; it now reads a Python complex via `PyComplex_AsCComplex`.
- default `complex` mapped to `double _Complex` / `NPY_CDOUBLE`, a different size than Fortran's single-precision default, which dropped the imaginary part. It now maps to `float _Complex` / `NPY_COMPLEX64`, mirroring default `real -> float`. `double complex` and `complex(8)` still map to double; `complex(dp)` via the kind map is unchanged.

## Verification

- `test/test_transform.py::TestTransform::test_optional_complex_scalar_kept` asserts the optional complex argument survives the transform. On master it fails: `AssertionError: 'z' not found in ['flag']`.
- `test/test_directc.py` complex mapping tests updated to the corrected single-precision defaults (and `double complex` / `complex(4)` added); 29 tests pass.
- `/tmp/f90wrap371-venv/bin/python -m pytest --import-mode=importlib -q /home/ert/code/f90wrap-dev/f90wrap/test/test_transform.py::TestTransform::test_optional_complex_scalar_kept /home/ert/code/f90wrap-dev/f90wrap/test/test_directc.py`: `30 passed in 0.27s`.
- `examples/issue371_optional_complex` round-trips a complex value through `present(z)` on both the f2py and `--direct-c` paths.

Compiler matrix for `examples/issue371_optional_complex`, using `make -f Makefile.meson test` with `DIRECTC=no` and `DIRECTC=yes`:

| Compiler | Version | f2py | direct-C |
| --- | --- | --- | --- |
| `gfortran` | GCC 16.1.1 | pass, `Ran 2 tests ... OK` | pass, `Ran 2 tests ... OK` |
| `flang` | LLVM flang 22.1.6 | pass, `Ran 2 tests ... OK` | pass, `Ran 2 tests ... OK` |
| `ifx` | 2025.0.4 | pass, `Ran 2 tests ... OK` | pass, `Ran 2 tests ... OK` |
| `nvfortran` | 26.3 | pass, `Ran 2 tests ... OK` | pass, `Ran 2 tests ... OK` |

The `ifx` runs need Intel's runtime library directory on the link path: `LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.0/lib`.

## Note

The absent-argument case for optional scalars under `--direct-c` (passing `None` so `present()` is `.false.`) is handled by a separate change for #369.
