### PR TITLE
Probe target compiler for opaque handle size

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -52,6 +52,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}*
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13.0
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build
 *~
 *.fpp
+!test/samples/*.fpp
 *.o
 *.mod
 *.a

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -41,6 +41,7 @@ EXAMPLES = \
 	issue32 \
 	issue353_selected_kind \
 	issue357_name_conflict \
+	issue378_flang_handle_size \
 	issue41_abstract_classes \
 	keep_single_interface \
 	keyword_renaming_issue160 \

--- a/examples/issue378_flang_handle_size/Makefile
+++ b/examples/issue378_flang_handle_size/Makefile
@@ -1,0 +1,18 @@
+include ../make.inc
+
+PY_MOD = example
+F90_SRC = example.f90
+F90WRAP_SRC = f90wrap_example.f90
+F90WRAP_FLAGS = --direct-c --fortran-compiler "$(F90) $(F90FLAGS)" -m $(PY_MOD)
+
+.PHONY: all clean test
+
+all: test
+
+clean:
+	rm -f *.mod *.o f90wrap_*.f90 _*.c $(PY_MOD).py .f2py_f2cmap
+
+test: clean
+	PYTHONPATH=../.. $(PYTHON) -m f90wrap $(F90WRAP_FLAGS) $(F90_SRC)
+	$(F90) $(F90FLAGS) -c $(F90_SRC) -o example.o
+	$(F90) $(F90FLAGS) -c $(F90WRAP_SRC) -o f90wrap_example.o

--- a/examples/issue378_flang_handle_size/Makefile.meson
+++ b/examples/issue378_flang_handle_size/Makefile.meson
@@ -1,0 +1,5 @@
+test:
+	$(MAKE) -f Makefile test
+
+clean:
+	$(MAKE) -f Makefile clean

--- a/examples/issue378_flang_handle_size/example.f90
+++ b/examples/issue378_flang_handle_size/example.f90
@@ -1,0 +1,8 @@
+module example
+    implicit none
+
+    type :: item
+        integer :: value
+        real, allocatable :: values(:)
+    end type item
+end module example

--- a/f90wrap/directc_cgen/__init__.py
+++ b/f90wrap/directc_cgen/__init__.py
@@ -44,7 +44,7 @@ class DirectCGenerator(cg.CodeGenerator):
     interop_info: Dict[ProcedureKey, InteropInfo]
     kind_map: Dict[str, Dict[str, str]]
     prefix: str = "f90wrap_"
-    handle_size: int = 4
+    handle_size: Optional[int] = None
     error_num_arg: Optional[str] = None
     error_msg_arg: Optional[str] = None
     callbacks: Optional[Iterable[str]] = None
@@ -53,6 +53,9 @@ class DirectCGenerator(cg.CodeGenerator):
 
     def __post_init__(self):
         """Initialize CodeGenerator parent after dataclass init."""
+        if self.handle_size is None:
+            from f90wrap.sizeof_fortran_t import sizeof_fortran_t
+            self.handle_size = sizeof_fortran_t()
         cg.CodeGenerator.__init__(self, indent="    ", max_length=120,
                                    continuation="\\", comment="//")
         if self.callbacks:

--- a/f90wrap/directc_cgen/module_helpers_array.py
+++ b/f90wrap/directc_cgen/module_helpers_array.py
@@ -53,7 +53,7 @@ def write_array_helper_body(gen: DirectCGenerator, helper: ModuleHelper, helper_
 
 def _write_handle_extraction(gen: DirectCGenerator) -> None:
     """Helper to extract handle from Python object."""
-    gen.write("int dummy_this[4] = {0, 0, 0, 0};")
+    gen.write(f"int dummy_this[{gen.handle_size}] = {{0}};")
     gen.write("if (dummy_handle != Py_None) {")
     gen.indent()
     gen.write("PyObject* handle_sequence = PySequence_Fast(dummy_handle, \"Handle must be a sequence\");")

--- a/f90wrap/meson.build
+++ b/f90wrap/meson.build
@@ -60,6 +60,8 @@ py3.install_sources(
     'parser.py',
     'pywrapgen.py',
     'runtime.py',
+    'sizeof_fortran.py',
+    'sizeoffortran.f90',
     'transform.py',
     'scripts/f2py_f90wrap.py',
     'scripts/f90doc.py',

--- a/f90wrap/pywrapgen.py
+++ b/f90wrap/pywrapgen.py
@@ -64,7 +64,8 @@ class PythonWrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
             relative=False,
             return_decoded=False,
             return_bool=False,
-            namespace_types=False):
+            namespace_types=False,
+            sizeof_fortran_t=None):
         if max_length is None:
             max_length = 80
         cg.CodeGenerator.__init__(
@@ -89,6 +90,7 @@ class PythonWrapperGenerator(ft.FortranVisitor, cg.CodeGenerator):
         self.relative = relative
         self.return_decoded = return_decoded
         self.return_bool = return_bool
+        self.sizeof_fortran_t = sizeof_fortran_t
         try:
             self._err_num_var, self._err_msg_var = auto_raise.split(',')
         except ValueError:
@@ -1227,6 +1229,11 @@ return %(el_name)s"""
             selfcomma="self, ",
             doc=self._format_doc_string(el),
             handle="self._handle" if not is_module_array else "",
+            sizeof_fortran_t=(
+                self.sizeof_fortran_t
+                if self.sizeof_fortran_t is not None
+                else "f90wrap.runtime.sizeof_fortran_t"
+            ),
         )
 
         if not is_module_array or not self.make_package:
@@ -1282,7 +1289,7 @@ if %(el_name)s is not None:
         %(el_name)s = None
 if %(el_name)s is None:
     try:
-        %(el_name)s = f90wrap.runtime.get_array(f90wrap.runtime.sizeof_fortran_t,
+        %(el_name)s = f90wrap.runtime.get_array(%(sizeof_fortran_t)s,
                                 %(handle)s,
                                 %(mod_name)s.%(subroutine_name)s)
     except TypeError:

--- a/f90wrap/scripts/main.py
+++ b/f90wrap/scripts/main.py
@@ -35,6 +35,7 @@ import logging
 import pprint
 import warnings
 import re
+import shlex
 
 from argparse import ArgumentParser
 from argparse import RawDescriptionHelpFormatter
@@ -43,7 +44,7 @@ from f90wrap import __version__
 
 from f90wrap import parser as fparse
 from f90wrap import fortran
-from f90wrap.sizeof_fortran_t import sizeof_fortran_t
+from f90wrap.sizeof_fortran import resolve_sizeof_fortran_t
 from f90wrap import transform as tf
 
 from f90wrap import f90wrapgen as fwrap
@@ -179,6 +180,14 @@ USAGE
                             help="Python functions return bool (instead of integer) when associated Fortran type is a logical")
         parser.add_argument('--direct-c', action='store_true', default=False,
                             help="Generate direct-C extension instead of relying on f2py")
+        parser.add_argument('--fortran-compiler',
+                            default=os.environ.get(
+                                'F90WRAP_FC',
+                                os.environ.get('F90', os.environ.get('FC')),
+                            ),
+                            help="Fortran compiler used to determine the opaque handle size")
+        parser.add_argument('--sizeof-fortran-t', type=int,
+                            help="Opaque handle size in integer(c_int) elements")
         parser.add_argument('--build', action='store_true', default=False,
                             help="Build extension module after generating wrappers")
         parser.add_argument('--clean-build', action='store_true', default=False,
@@ -332,8 +341,27 @@ USAGE
         logger.info('Argument name map:')
         logger.info(pprint.pformat(argument_name_map))
 
-        fsize = sizeof_fortran_t()
-        logger.info(f'Size of Fortran derived type pointers is {fsize} bytes.')
+        compiler_command = args.fortran_compiler
+        if args.build and not compiler_command:
+            compiler_command = 'gfortran'
+        compiler_parts = shlex.split(compiler_command) if compiler_command else []
+        compiler_flags = shlex.split(os.environ.get('FFLAGS', ''))
+        if args.build and not compiler_flags:
+            compiler_flags = ['-fPIC']
+        probe_command = (
+            shlex.join(compiler_parts + compiler_flags)
+            if compiler_parts
+            else None
+        )
+
+        fsize = resolve_sizeof_fortran_t(
+            explicit_size=args.sizeof_fortran_t,
+            compiler=probe_command,
+        )
+        logger.info(
+            'Fortran derived type handles use %d integer(c_int) elements.',
+            fsize,
+        )
 
         # parse input Fortran source files
         logger.info(f'Parsing Fortran source files {args.files} ...')
@@ -473,6 +501,7 @@ USAGE
             return_decoded=return_decoded,
             return_bool=return_bool,
             namespace_types=bool(args.direct_c),
+            sizeof_fortran_t=fsize,
         ).visit(py_tree)
         fwrap.F90WrapperGenerator(
             prefix,
@@ -566,11 +595,18 @@ USAGE
             from f90wrap import build
 
             logger.info("Building extension module...")
+            build_env = None
+            if compiler_parts:
+                build_env = {
+                    'F90': compiler_parts[0],
+                    'FFLAGS': ' '.join(compiler_parts[1:] + compiler_flags),
+                }
             ret = build.build_extension(
                 module_name=args.mod_name,
                 source_files=args.files,
                 package_mode=args.package,
                 clean_first=args.clean_build,
+                env=build_env,
                 verbose=args.verbose > 0
             )
 

--- a/f90wrap/sizeof_fortran.py
+++ b/f90wrap/sizeof_fortran.py
@@ -1,0 +1,59 @@
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def resolve_sizeof_fortran_t(explicit_size=None, compiler=None):
+    if explicit_size is not None:
+        if explicit_size <= 0:
+            raise ValueError("--sizeof-fortran-t must be positive")
+        return explicit_size
+    if compiler:
+        return probe_sizeof_fortran_t(compiler)
+    from f90wrap.sizeof_fortran_t import sizeof_fortran_t as installed_sizeof_fortran_t
+    return installed_sizeof_fortran_t()
+
+
+def probe_sizeof_fortran_t(compiler):
+    command = shlex.split(compiler)
+    if not command:
+        raise ValueError("Fortran compiler command is empty")
+
+    source = Path(__file__).with_name("sizeoffortran.f90")
+    with tempfile.TemporaryDirectory(prefix="f90wrap-sizeof-") as tmp:
+        tmp_path = Path(tmp)
+        driver = tmp_path / "probe.f90"
+        executable = tmp_path / ("probe.exe" if os.name == "nt" else "probe")
+        driver.write_text(
+            "program probe\n"
+            "  implicit none\n"
+            "  integer :: size_out\n"
+            "  call sizeof_fortran_t(size_out)\n"
+            "  print *, size_out\n"
+            "end program probe\n"
+        )
+        _run(command + [str(source), str(driver), "-o", str(executable)])
+        result = _run([str(executable)])
+
+    try:
+        size = int(result.stdout.strip())
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Fortran handle-size probe returned {result.stdout.strip()!r}"
+        ) from exc
+    if size <= 0:
+        raise RuntimeError(f"Fortran handle-size probe returned {size}")
+    return size
+
+
+def _run(command):
+    try:
+        result = subprocess.run(command, capture_output=True, text=True)
+    except OSError as exc:
+        raise RuntimeError(f"Cannot run {' '.join(command)}: {exc}") from exc
+    if result.returncode != 0:
+        output = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"{' '.join(command)} failed: {output}")
+    return result

--- a/f90wrap/sizeoffortran.f90
+++ b/f90wrap/sizeoffortran.f90
@@ -1,21 +1,26 @@
 subroutine sizeof_fortran_t(size_out)
 
-  type ptr_type
-     type(ptr_type), pointer :: p => NULL()
-  end type ptr_type
-  type(ptr_type) :: ptr_t
-  integer, allocatable, dimension(:) :: ptr_int_t
+    use iso_c_binding, only: c_int
 
-  type ptr_class
-     class(ptr_class), pointer :: p => NULL()
-  end type ptr_class
-  type(ptr_class) :: ptr_c
-  integer, allocatable, dimension(:) :: ptr_int_c
+    implicit none
 
-  integer, intent(out) :: size_out
+    type ptr_type
+        type(ptr_type), pointer :: p => null()
+    end type ptr_type
+    type(ptr_type) :: ptr_t
+    integer(c_int), allocatable, dimension(:) :: ptr_int_t
 
-  ptr_t_size =  size(transfer(ptr_t, ptr_int_t))
-  ptr_c_size =  size(transfer(ptr_c, ptr_int_c))
-  size_out = max(ptr_t_size, ptr_c_size)
+    type ptr_class
+        class(ptr_class), pointer :: p => null()
+    end type ptr_class
+    type(ptr_class) :: ptr_c
+    integer(c_int), allocatable, dimension(:) :: ptr_int_c
+
+    integer, intent(out) :: size_out
+    integer :: ptr_t_size, ptr_c_size
+
+    ptr_t_size = size(transfer(ptr_t, ptr_int_t))
+    ptr_c_size = size(transfer(ptr_c, ptr_int_c))
+    size_out = max(ptr_t_size, ptr_c_size)
 
 end subroutine sizeof_fortran_t

--- a/test/samples/DNAD.fpp
+++ b/test/samples/DNAD.fpp
@@ -1,0 +1,1818 @@
+!******************************************************************************
+!* Dual Number Automatic Differentiation (DNAD) of Fortran Codes
+!*-----------------------------------------------------------------------------
+!* COPYRIGHT (c) Joshua Hodson, All rights reserved, you are free to copy,
+!* modify, or translate this code to other languages such as c/c++. This is a
+!* fork of the original Fortran DNAD module developed by Dr. Wenbin Yu. See
+!* original copyright information below. You can download the original version
+!* at https://cdmhub.org/resources/374
+!*
+!* COPYRIGHT (c) Wenbin Yu, All rights reserved, you are free to copy,
+!* modify or translate this code to other languages such as c/c++. If
+!* you find a bug please let me know through wenbinyu.heaven@gmail.com. If
+!* you added new functions and want to share with others, please let me know
+!* too. You are welcome to share your successful stories with us through
+!* http://groups.google.com/group/hifi-comp.
+!******************************************************************************
+!* Acknowledgements
+!*-----------------------------------------------------------------------------
+!* The development of DNAD is supported, in part, by the Chief Scientist
+!* Innovative Research Fund at AFRL/RB WPAFB, and by Department of Army
+!* SBIR (Topic A08-022) through Advanced Dynamics Inc. The views and
+!* conclusions contained herein are those of the authors and should not be
+!* interpreted as necessarily representing the official policies or
+!* endorsement, either expressed or implied, of the funding agency.
+!*
+!* Additional development of DNAD has been supported under a Department of
+!* Energy (DOE) Nuclear Energy University Program (NEUP) Graduate Fellowship.
+!* Any opinions, findings, conclusions or recommendations expressed in this
+!* publication are those of the authors and do not necessarily reflect the
+!* views of the Department of Energy Office of Nuclear Energy.
+!******************************************************************************
+!* Citation
+!*-----------------------------------------------------------------------------
+!* Your citation of the following two papers is appreciated:
+!* Yu, W. and Blair, M.: "DNAD, a Simple Tool for Automatic Differentiation of
+!* Fortran Codes Using Dual Numbers," Computer Physics Communications, vol.
+!* 184, 2013, pp. 1446-1452.
+!*
+!* Spall, R. and Yu, W.: "Imbedded Dual-Number Automatic Differentiation for
+!* CFD Sensitivity Analysis," Journal of Fluids Engineering, vol. 135, 2013,
+!* 014501.
+!******************************************************************************
+!* Quick Start Guide
+!*-----------------------------------------------------------------------------
+!* To integrate DNAD into an existing Fortran program, do the following:
+!*
+!*   1. Include the DNAD module in the source files by adding "use dnadmod" to
+!*      the beginning of all modules, global functions, and global subroutines
+!*      that include definitions of floating-point variables.
+!*   2. Redefine all floating-point variables as type(dual). This can be done
+!*      using precompiler directives so that the integration can be turned on
+!*      or off at compile-time, eliminating the need for maintaining two
+!*      separate code bases for the same project.
+!*   3. All I/O involving floating-point variables will need to be examined.
+!*      A method will need to be determined for inputting and outputting
+!*      derivative values. This customization is typically unique for each
+!*      piece of software and needs to be determined on a case-by-case basis.
+!*   4. When compiling DNAD, use the compiler option "-Dndv=#", where # is the
+!*      number of design variables desired. This sizes the derivative array
+!*      that is stored with each floating point number.
+!*   5. When compiling DNAD, use compiler options to specify precision. If no
+!*      compiler options are specified, DNAD will default to single-precision
+!*      floating-point arithmetic. Most popular Fortran compilers provide
+!*      options for specifying precision at compile-time so that it does not
+!*      have to be hard-coded into the source code. For example, use the
+!*      "-fdefault-real-8" compiler in gfortran or the "-r8" compiler option
+!*      with Intel Fortran to compile DNAD as double-precision.
+!*   6. Modify the compilation process for the target software to include the
+!*      DNAD module in the resulting executable or library.
+!******************************************************************************
+!* Change Log
+!*-----------------------------------------------------------------------------
+!*
+!*  2016-04-29  Joshua Hodson
+!*  - Updated copyright, acknowledgments, and quick start guide.
+!*  - Removed overloads for single-precision reals.
+!*  - Added tan, dtan, atan, and atan2 intrinsic function overloads.
+!*  - Removed macro for precision and defined all floating-point variables as
+!*    default real. Compiler options can now be used to set precision.
+!*  - Added checks for undefined derivatives when only constants are used in
+!*    the calculation (i.e. all partial derivatives are zero). This limits the
+!*    perpetuation of NaN values in the code.
+!*  - Combined the header and source files into a single file.
+!*
+!*  2015-07-29  Joshua Hodson
+!*  - Added maxloc intrinsic function overload.
+!*  - Converted UPPERCASE to lowercase for readability.
+!*  - Added macros for defining precision and number of design variables.
+!*  - Renamed module from Dual_Num_Auto_Diff to dnadmod
+!*  - Renamed dual number type from DUAL_NUM to dual
+!*  - Renamed components of dual number type from (xp_ad_, xp_ad_) to (x, dx)
+!*
+!*  2014-06-05  Wenbin Yu
+!*  - Forked from original DNAD repository, see https://cdmhub.org/resources/374
+!*
+!******************************************************************************
+
+! Number of design variables (default = 1)
+#ifndef ndv
+#define ndv 1
+#endif
+
+module dnadmod
+
+    implicit none
+
+    private
+
+    real :: negative_one = -1.0
+    type,public:: dual  ! make this private will create difficulty to use the
+                        ! original write/read commands, hence x and dx are
+                        ! variables which can be accessed using D%x and D%dx in
+                        ! other units using this module in which D is defined
+                        ! as type(dual).
+        sequence
+        real :: x  ! functional value
+        real :: dx(ndv)  ! derivative
+    end type dual
+
+
+!******** Interfaces for operator overloading
+    public assignment (=)
+    interface assignment (=)
+        module procedure assign_di  ! dual=integer, elemental
+        module procedure assign_dr  ! dual=real, elemental
+        module procedure assign_id  ! integer=dual, elemental
+    end interface
+
+
+    public operator (+)
+    interface operator (+)
+        module procedure add_d   ! +dual number, elemental
+        module procedure add_dd  ! dual + dual, elemental
+        module procedure add_di  ! dual + integer, elemental
+        module procedure add_dr  ! dual + real, elemental
+        module procedure add_id  ! integer + dual, elemental
+        module procedure add_rd  ! real + dual, elemental
+    end interface
+
+    public operator (-)
+    interface operator (-)
+        module procedure minus_d   ! negate a dual number,elemental
+        module procedure minus_dd  ! dual -dual,elemental
+        module procedure minus_di  ! dual-integer,elemental
+        module procedure minus_dr  ! dual-real,elemental
+        module procedure minus_id  ! integer-dual,elemental
+        module procedure minus_rd  ! real-dual,elemental
+    end interface
+
+    public operator (*)
+    interface operator (*)
+        module procedure mult_dd    ! dual*dual, elemental
+        module procedure mult_di    ! dual*integer,elemental
+        module procedure mult_dr    ! dual*real,elemental
+        module procedure mult_id    ! integer*dual,elemental
+        module procedure mult_rd    ! real*dual,elemental
+    end interface
+
+    public operator (/)
+    interface operator (/)
+        module procedure div_dd ! dual/dual,elemental
+        module procedure div_di ! dual/integer, elemental
+        module procedure div_dr ! dual/real,emental
+        module procedure div_id ! integer/dual, elemental
+        module procedure div_rd ! real/dual, elemental
+    end interface
+
+    public operator (**)
+    interface operator (**)
+        module procedure pow_i ! dual number to an integer power,elemental
+        module procedure pow_r ! dual number to a real power, elemental
+        module procedure pow_d ! dual number to a dual power, elemental
+    end interface
+
+    public operator (==)
+    interface operator (==)
+        module procedure eq_dd ! compare two dual numbers, elemental
+        module procedure eq_di ! compare a dual and an integer, elemental
+        module procedure eq_dr ! compare a dual and a real, elemental
+        module procedure eq_id ! compare integer with a dual number, elemental
+        module procedure eq_rd ! compare a real with a dual number, elemental
+    end interface
+
+    public operator (<=)
+    interface operator (<=)
+        module procedure le_dd  ! compare two dual numbers, elemental
+        module procedure le_di  ! compare a dual and an integer, elemental
+        module procedure le_dr  ! compare a dual and a real,elemental
+        module procedure le_id ! compare integer with a dual number, elemental
+        module procedure le_rd ! compare a real with a dual number, elemental
+    end interface
+
+    public operator (<)
+    interface operator (<)
+        module procedure lt_dd  !compare two dual numbers, elemental
+        module procedure lt_di  !compare a dual and an integer, elemental
+        module procedure lt_dr  !compare dual with a real, elemental
+        module procedure lt_id ! compare integer with a dual number, elemental
+        module procedure lt_rd ! compare a real with a dual number, elemental
+    end interface
+
+    public operator (>=)
+    interface operator (>=)
+        module procedure ge_dd ! compare two dual numbers, elemental
+        module procedure ge_di ! compare dual with integer, elemental
+        module procedure ge_dr ! compare dual with a real number, elemental
+        module procedure ge_id ! compare integer with a dual number, elemental
+        module procedure ge_rd ! compare a real with a dual number, elemental
+    end interface
+
+    public operator (>)
+    interface operator (>)
+        module procedure gt_dd  !compare two dual numbers, elemental
+        module procedure gt_di  !compare a dual and an integer, elemental
+        module procedure gt_dr  !compare dual with a real, elemental
+        module procedure gt_id ! compare integer with a dual number, elemental
+        module procedure gt_rd ! compare a real with a dual number, elemental
+    end interface
+
+    public operator (/=)
+    interface operator (/=)
+        module procedure ne_dd  !compare two dual numbers, elemental
+        module procedure ne_di  !compare a dual and an integer, elemental
+        module procedure ne_dr  !compare dual with a real, elemental
+        module procedure ne_id ! compare integer with a dual number, elemental
+        module procedure ne_rd ! compare a real with a dual number, elemental
+    end interface
+
+
+!------------------------------------------------
+! Interfaces for intrinsic functions overloading
+!------------------------------------------------
+    public abs
+    interface abs
+        module procedure abs_d  ! absolute value of a dual number, elemental
+    end interface
+    
+    public dabs
+    interface dabs
+        module procedure abs_d ! same as abs, used for some old fortran commands
+    end interface
+    
+    public acos
+    interface acos
+        module procedure acos_d ! arccosine of a dual number, elemental
+    end interface
+    
+    public asin
+    interface asin
+        module procedure asin_d ! arcsine of a dual number, elemental
+    end interface
+    
+    public atan
+    interface atan
+        module procedure atan_d ! arctan of a dual number, elemental
+    end interface
+    
+    public atan2
+    interface atan2
+        module procedure atan2_d ! arctan of a dual number, elemental
+    end interface
+    
+    public cos
+    interface cos
+        module procedure cos_d ! cosine of a dual number, elemental
+    end interface
+    
+    public dcos
+    interface dcos
+        module procedure cos_d ! cosine of a dual number, elemental
+    end interface
+    
+    public dot_product
+    interface dot_product
+        module procedure dot_product_dd ! dot product two dual number vectors
+    end interface
+    
+    public exp
+    interface exp
+        module procedure exp_d ! exponential of a dual number, elemental
+    end interface
+    
+    public int
+    interface int
+        module procedure int_d ! integer part of a dual number, elemental
+    end interface
+    
+    public log
+    interface log
+        module procedure log_d ! log of a dual number, elemental
+    end interface
+    
+    public log10
+    interface log10
+        module procedure log10_d ! log of a dual number, elemental
+    end interface
+    
+    public matmul
+    interface matmul
+        module procedure matmul_dd ! multiply two dual matrices
+        module procedure matmul_dv ! multiply a dual matrix with a dual vector
+        module procedure matmul_vd ! multiply a dual vector with a dual matrix
+    end interface
+    
+    
+    public max
+    interface max
+        module procedure max_dd ! max of from two to four dual numbers, elemental
+        module procedure max_di ! max of a dual number and an integer, elemental
+        module procedure max_dr ! max of a dual number and a real, elemental
+        module procedure max_rd ! max of a real,and a dual number,  elemental
+    end interface
+    
+    public dmax1
+    interface dmax1
+        module procedure max_dd ! max of from two to four dual numbers, elemental
+    end interface
+    
+    public maxval
+    interface maxval
+        module procedure maxval_d ! maxval of a dual number vector
+    end interface
+    
+    public min
+    interface min
+        module procedure min_dd ! min of from two to four dual numbers, elemental
+        module procedure min_dr ! min of a dual and a real, elemental
+    end interface
+    
+    public dmin1
+    interface dmin1
+        module procedure min_dd ! min of from two to four dual numbers, elemental
+    end interface
+    
+    public minval
+    interface minval
+        module procedure minval_d ! obtain the maxval  of a dual number vectgor
+    end interface
+    
+    public nint
+    interface nint
+        module procedure nint_d ! nearest integer to the argument, elemental
+    end interface
+    
+    public sign
+    interface  sign
+      module procedure  sign_dd ! sign(a,b) with two dual numbers, elemental
+      module procedure  sign_rd ! sign(a,b) with a real and a dual, elemental
+    end interface
+    
+    public sin
+    interface sin
+        module procedure sin_d ! obtain sine of a dual number, elemental
+    end interface
+    
+    public dsin
+    interface dsin
+        module procedure sin_d ! obtain sine of a dual number, elemental
+    end interface
+    
+    public tan
+    interface tan
+        module procedure tan_d ! obtain sine of a dual number, elemental
+    end interface
+    
+    public dtan
+    interface dtan
+        module procedure tan_d ! obtain sine of a dual number, elemental
+    end interface
+    
+    public sqrt
+    interface sqrt
+        module procedure sqrt_d ! obtain the sqrt of a dual number, elemental
+    end interface
+    
+    public sum
+    interface sum
+        module procedure sum_d ! sum a dual array
+    end interface
+    
+    public maxloc
+    interface maxloc
+        module procedure maxloc_d ! location of max in a dual array
+    end interface
+
+contains
+
+!*********Begin: functions/subroutines for overloading operators
+
+!******* Begin: (=)
+!---------------------
+
+    !-----------------------------------------
+    ! dual = integer
+    ! <u, du> = <i, 0>
+    !-----------------------------------------
+    elemental subroutine assign_di(u, i)
+         type(dual), intent(out) :: u
+         integer, intent(in) :: i
+
+         u%x = real(i)  ! This is faster than direct assignment
+         u%dx = 0.0
+
+    end subroutine assign_di
+
+
+    !-----------------------------------------
+    ! dual = real(double)
+    ! <u, du> = <r, 0>
+    !-----------------------------------------
+    elemental subroutine assign_dr(u, r)
+        type(dual), intent(out) :: u
+        real, intent(in) :: r
+
+        u%x = r
+        u%dx = 0.0
+
+    end subroutine assign_dr
+
+
+    !-----------------------------------------
+    ! integer = dual
+    ! i = <u, du>
+    !-----------------------------------------
+    elemental subroutine assign_id(i, v)
+         type(dual), intent(in) :: v
+         integer, intent(out) :: i
+
+         i = int(v%x)
+
+    end subroutine assign_id
+
+!******* End: (=)
+!---------------------
+
+
+!******* Begin: (+)
+!---------------------
+
+    !-----------------------------------------
+    ! Unary positive
+    ! <res, dres> = +<u, du>
+    !-----------------------------------------
+    elemental function add_d(u) result(res)
+         type(dual), intent(in) :: u
+         type(dual) :: res
+
+         res = u  ! Faster than assigning component wise
+
+    end function add_d
+
+
+    !-----------------------------------------
+    ! dual + dual
+    ! <res, dres> = <u, du> + <v, dv> = <u + v, du + dv>
+    !-----------------------------------------
+    elemental function add_dd(u, v) result(res)
+         type(dual), intent(in) :: u, v
+         type(dual) :: res
+
+         res%x = u%x + v%x
+         res%dx = u%dx + v%dx
+
+    end function add_dd
+
+
+    !-----------------------------------------
+    ! dual + integer
+    ! <res, dres> = <u, du> + i = <u + i, du>
+    !-----------------------------------------
+    elemental function add_di(u, i) result(res)
+         type(dual), intent(in) :: u
+         integer, intent(in) :: i
+         type(dual) :: res
+
+         res%x = real(i) + u%x
+         res%dx = u%dx
+
+    end function add_di
+
+
+    !-----------------------------------------
+    ! dual + double
+    ! <res, dres> = <u, du> + <r, 0> = <u + r, du>
+    !-----------------------------------------
+    elemental function add_dr(u, r) result(res)
+        type(dual), intent(in) :: u
+        real, intent(in) :: r
+        type(dual) :: res
+
+        res%x = r + u%x
+        res%dx = u%dx
+
+    end function add_dr
+
+
+    !-----------------------------------------
+    ! integer + dual
+    ! <res, dres> = <i, 0> + <v, dv> = <i + v, dv>
+    !-----------------------------------------
+    elemental function add_id(i, v) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        res%x = real(i) + v%x
+        res%dx = v%dx
+
+    end function add_id
+
+
+    !-----------------------------------------
+    ! double + dual
+    ! <res, dres> = <r, 0> + <v, dv> = <r + v, dv>
+    !-----------------------------------------
+    elemental function add_rd(r, v) result(res)
+        real, intent(in) :: r
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        res%x = r + v%x
+        res%dx = v%dx
+
+    end function add_rd
+
+!******* End: (+)
+!---------------------
+
+
+!******* Begin: (-)
+!---------------------
+
+    !-------------------------------------------------
+    ! negate a dual
+    ! <res, dres> = -<u, du>
+    !-------------------------------------------------
+    elemental function minus_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = -u%x
+        res%dx = -u%dx
+
+    end function minus_d
+
+
+    !-------------------------------------------------
+    ! dual - dual
+    ! <res, dres> = <u, du> - <v, dv> = <u - v, du - dv>
+    !-------------------------------------------------
+    elemental function minus_dd(u, v) result(res)
+        type(dual), intent(in) :: u, v
+        type(dual) :: res
+
+        res%x = u%x - v%x
+        res%dx = u%dx - v%dx
+
+    end function minus_dd
+
+    !-------------------------------------------------
+    ! dual - integer
+    ! <res, dres> = <u, du> - i = <u - i, du>
+    !-------------------------------------------------
+    elemental function minus_di(u, i) result(res)
+        type(dual), intent(in) :: u
+        integer, intent(in) :: i
+        type(dual) :: res
+
+        res%x = u%x - real(i)
+        res%dx = u%dx
+
+    end function minus_di
+
+    
+    !-------------------------------------------------
+    ! dual - double
+    ! <res, dres> = <u, du> - r = <u - r, du>
+    !-------------------------------------------------
+    elemental function minus_dr(u, r) result(res)
+        type (dual), intent(in) :: u
+        real,intent(in) :: r
+        type(dual) :: res
+
+        res%x = u%x - r
+        res%dx = u%dx
+
+    end function minus_dr
+
+
+    !-------------------------------------------------
+    ! integer - dual
+    ! <res, dres> = i - <v, dv> = <i - v, -dv>
+    !-------------------------------------------------
+    elemental function minus_id(i, v) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        res%x = real(i) - v%x
+        res%dx = -v%dx
+
+    end function minus_id
+
+
+    !-------------------------------------------------
+    ! double - dual
+    ! <res, dres> = r - <v, dv> = <r - v, -dv>
+    !-------------------------------------------------
+    elemental function minus_rd(r, v) result(res)
+         real, intent(in) :: r
+         type(dual), intent(in) :: v
+         type(dual) :: res
+
+        res%x = r - v%x
+        res%dx = -v%dx
+
+    end function minus_rd
+
+!******* END: (-)
+!---------------------
+
+
+!******* BEGIN: (*)
+!---------------------
+
+    !----------------------------------------
+    ! dual * dual
+    ! <res, dres> = <u, du> * <v, dv> = <u * v, u * dv + v * du>
+    !----------------------------------------
+    elemental function mult_dd(u, v) result(res)
+        type(dual), intent(in) :: u, v
+        type(dual) :: res
+
+        res%x = u%x * v%x
+        res%dx = u%x * v%dx + v%x * u%dx
+
+    end function mult_dd
+
+
+    !-----------------------------------------
+    ! dual * integer
+    ! <res, dres> = <u, du> * i = <u * i, du * i>
+    !-----------------------------------------
+    elemental function mult_di(u, i) result(res)
+        type(dual), intent(in) :: u
+        integer, intent(in) :: i
+        type(dual) :: res
+
+        real :: r
+
+        r = real(i)
+        res%x = r * u%x
+        res%dx = r * u%dx
+
+    end function mult_di
+
+    !-----------------------------------------
+    ! dual * double
+    ! <res, dres> = <u, du> * r = <u * r, du * r>
+    !----------------------------------------
+    elemental function mult_dr(u, r) result(res)
+        type(dual), intent(in) :: u
+        real, intent(in) :: r
+        type(dual) :: res
+
+        res%x = u%x * r
+        res%dx = u%dx * r
+
+    end function mult_dr
+
+
+    !-----------------------------------------
+    ! integer * dual
+    ! <res, dres> = i * <v, dv> = <i * v, i * dv>
+    !-----------------------------------------
+    elemental function mult_id(i, v) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        real :: r
+
+        r = real(i)
+        res%x = r * v%x
+        res%dx = r * v%dx
+
+    end function mult_id
+
+
+    !-----------------------------------------
+    ! double * dual
+    ! <res, dres> = r * <v, dv> = <r * v, r * dv>
+    !-----------------------------------------
+    elemental function mult_rd(r, v) result(res)
+        real, intent(in) :: r
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        res%x = r * v%x
+        res%dx = r * v%dx
+
+    end function mult_rd
+
+!******* END: (*)
+!---------------------
+
+
+!******* BEGIN: (/)
+!---------------------
+
+    !-----------------------------------------
+    ! dual / dual
+    ! <res, dres> = <u, du> / <v, dv> = <u / v, du / v - u * dv / v^2>
+    !-----------------------------------------
+    elemental function div_dd(u, v) result(res)
+        type(dual), intent(in) :: u, v
+        type(dual) :: res
+
+        real :: inv
+
+        inv = 1.0 / v%x
+        res%x = u%x * inv
+        res%dx = (u%dx - res%x * v%dx) * inv
+
+    end function div_dd
+
+
+    !-----------------------------------------
+    ! dual / integer
+    ! <res, dres> = <u, du> / i = <u / i, du / i>
+    !-----------------------------------------
+    elemental function div_di(u, i) result(res)
+        type(dual), intent(in) :: u
+        integer, intent(in) :: i
+        type(dual) :: res
+
+        real :: inv
+
+        inv = 1.0 / real(i)
+        res%x = u%x * inv
+        res%dx = u%dx * inv
+
+    end function div_di
+
+
+    !-----------------------------------------
+    ! dual / double
+    ! <res, dres> = <u, du> / r = <u / r, du / r>
+    !----------------------------------------
+    elemental function div_dr(u, r) result(res)
+        type(dual), intent(in) :: u
+        real, intent(in) :: r
+        type(dual):: res
+
+        real :: inv
+
+        inv = 1.0 / r
+        res%x = u%x * inv
+        res%dx = u%dx * inv
+
+    end function div_dr
+
+
+    !-----------------------------------------
+    ! integer / dual
+    ! <res, dres> = i / <v, dv> = <i / v, -i / v^2 * du>
+    !-----------------------------------------
+    elemental function div_id(i, v) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        real :: inv
+
+        inv = 1.0 / v%x
+        res%x = real(i) * inv
+        res%dx = -res%x * inv * v%dx
+
+    end function div_id
+
+
+    !-----------------------------------------
+    ! double / dual
+    ! <res, dres> = r / <u, du> = <r / u, -r / u^2 * du>
+    !-----------------------------------------
+    elemental function div_rd(r, v) result(res)
+        real, intent(in) :: r
+        type(dual), intent(in) :: v
+        type(dual) :: res
+
+        real :: inv
+
+        inv = 1.0 / v%x
+        res%x = r * inv
+        res%dx = -res%x * inv * v%dx
+
+    end function div_rd
+
+!******* END: (/)
+!---------------------
+
+!******* BEGIN: (**)
+!---------------------
+
+    !-----------------------------------------
+    ! power(dual, integer)
+    ! <res, dres> = <u, du> ^ i = <u ^ i, i * u ^ (i - 1) * du>
+    !-----------------------------------------
+    elemental function pow_i(u, i) result(res)
+        type(dual), intent(in) :: u
+        integer, intent(in) :: i
+        type(dual) :: res
+
+        real :: pow_x
+
+        pow_x = u%x ** (i - 1)
+        res%x = u%x * pow_x
+        res%dx = real(i) * pow_x * u%dx
+
+    end function pow_i
+
+    !-----------------------------------------
+    ! power(dual, double)
+    ! <res, dres> = <u, du> ^ r = <u ^ r, r * u ^ (r - 1) * du>
+    !-----------------------------------------
+    elemental function pow_r(u, r) result(res)
+        type(dual), intent(in) :: u
+        real, intent(in) :: r
+        type(dual) :: res
+
+        real :: pow_x
+
+        pow_x = u%x ** (r - 1.0)
+        res%x = u%x * pow_x
+        res%dx = r * pow_x * u%dx
+
+    end function pow_r
+
+    !-----------------------------------------
+    ! POWER dual numbers to a dual power
+    ! <res, dres> = <u, du> ^ <v, dv>
+    !     = <u ^ v, u ^ v * (v / u * du + Log(u) * dv)>
+    !-----------------------------------------
+    elemental function pow_d(u, v) result(res)
+        type(dual), intent(in)::u, v
+        type(dual) :: res
+
+        res%x = u%x ** v%x
+        res%dx = res%x * (v%x / u%x * u%dx + log(u%x) * v%dx)
+
+    end function pow_d
+
+!******* END: (**)
+!---------------------
+
+
+!******* BEGIN: (==)
+!---------------------
+    !-----------------------------------------
+    ! compare two dual numbers,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function eq_dd(lhs, rhs) result(res)
+         type(dual), intent(in) :: lhs, rhs
+         logical :: res
+
+         res = (lhs%x == rhs%x)
+
+    end function eq_dd
+
+
+    !-----------------------------------------
+    ! compare a dual with an integer,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function eq_di(lhs, rhs) result(res)
+         type(dual), intent(in) :: lhs
+         integer, intent(in) :: rhs
+         logical :: res
+
+         res = (lhs%x == real(rhs))
+
+    end function eq_di
+
+
+    !-----------------------------------------
+    ! compare a dual number with a real number,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function eq_dr(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        real, intent(in) :: rhs
+        logical::res
+
+        res = (lhs%x == rhs)
+
+    end function eq_dr
+
+
+    !-----------------------------------------
+    ! compare an integer with a dual,
+    ! simply compare the functional value.
+    !----------------------------------------
+    elemental function eq_id(lhs, rhs) result(res)
+         integer, intent(in) :: lhs
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (lhs == rhs%x)
+
+    end function eq_id
+
+
+    !-----------------------------------------
+    ! compare a real with a dual,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function eq_rd(lhs, rhs) result(res)
+         real, intent(in) :: lhs
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (lhs == rhs%x)
+
+    end function eq_rd
+
+!******* END: (==)
+!---------------------
+
+
+!******* BEGIN: (<=)
+!---------------------
+    !-----------------------------------------
+    ! compare two dual numbers, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function le_dd(lhs, rhs) result(res)
+         type(dual), intent(in) :: lhs, rhs
+         logical :: res
+
+         res = (lhs%x <= rhs%x)
+
+    end function le_dd
+
+
+    !-----------------------------------------
+    ! compare a dual with an integer,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function le_di(lhs, rhs) result(res)
+         type(dual), intent(in) :: lhs
+         integer, intent(in) :: rhs
+         logical :: res
+
+         res = (lhs%x <= rhs)
+
+    end function le_di
+
+
+    !-----------------------------------------
+    ! compare a dual number with a real number,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function le_dr(lhs, rhs) result(res)
+         type(dual), intent(in) :: lhs
+         real, intent(in) :: rhs
+         logical :: res
+
+         res = (lhs%x <= rhs)
+
+    end function le_dr
+
+
+    !-----------------------------------------
+    ! compare a dual number with an integer,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function le_id(i, rhs) result(res)
+         integer, intent(in) :: i
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (i <= rhs%x)
+
+    end function le_id
+
+
+    !-----------------------------------------
+    ! compare a real with a dual,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function le_rd(lhs, rhs) result(res)
+         real, intent(in) :: lhs
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (lhs <= rhs%x)
+
+    end function le_rd
+
+!******* END: (<=)
+!---------------------
+
+!******* BEGIN: (<)
+!---------------------
+    !-----------------------------------------
+    ! compare two dual numbers, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function lt_dd(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs, rhs
+        logical :: res
+
+        res = (lhs%x < rhs%x)
+
+    end function lt_dd
+
+    !-----------------------------------------
+    ! compare a dual with an integer,
+    ! simply compare the functional value.
+    !-----------------------------------------
+    elemental function lt_di(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        integer, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x < rhs)
+
+    end function lt_di
+
+
+    !-----------------------------------------
+    ! compare a dual number with a real number, simply compare
+    ! the functional value.
+    !----------------------------------------
+    elemental function lt_dr(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        real, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x < rhs)
+
+    end function lt_dr
+
+
+    !-----------------------------------------
+    ! compare a dual number with an integer
+    !-----------------------------------------
+    elemental function lt_id(i, rhs) result(res)
+         integer, intent(in) :: i
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (i < rhs%x)
+
+    end function lt_id
+
+
+    !-----------------------------------------
+    ! compare a real with a dual
+    !----------------------------------------
+    elemental function lt_rd(lhs, rhs) result(res)
+         real, intent(in) :: lhs
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (lhs < rhs%x)
+
+    end function lt_rd
+
+!******* END: (<)
+!---------------------
+
+!******* BEGIN: (>=)
+!---------------------
+    !-----------------------------------------
+    ! compare two dual numbers, simply compare
+    ! the functional value.
+    !----------------------------------------
+    elemental function ge_dd(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs, rhs
+        logical :: res
+
+        res = (lhs%x >= rhs%x)
+
+    end function ge_dd
+
+
+    !-----------------------------------------
+    ! compare a dual with an integer
+    !-----------------------------------------
+    elemental function ge_di(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        integer, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x >= rhs)
+
+    end function ge_di
+
+
+    !-----------------------------------------
+    ! compare a dual number with a real number, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function ge_dr(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        real, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x >= rhs)
+
+    end function ge_dr
+
+
+    !-----------------------------------------
+    ! compare a dual number with an integer
+    !-----------------------------------------
+    elemental function ge_id(i, rhs) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: rhs
+        logical :: res
+
+        res = (i >= rhs%x)
+
+    end function ge_id
+
+
+    !-----------------------------------------
+    ! compare a real with a dual
+    !-----------------------------------------
+    elemental function ge_rd(lhs, rhs) result(res)
+         real, intent(in) :: lhs
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (lhs >= rhs%x)
+
+    end function ge_rd
+
+!******* END: (>=)
+!---------------------
+
+!******* BEGIN: (>)
+!---------------------
+    !-----------------------------------------
+    ! compare two dual numbers, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function gt_dd(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs, rhs
+        logical :: res
+
+        res = (lhs%x > rhs%x)
+
+    end function gt_dd
+
+
+    !-----------------------------------------
+    ! compare a dual with an integer
+    !-----------------------------------------
+    elemental function gt_di(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        integer, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x > rhs)
+
+    end function gt_di
+
+
+    !-----------------------------------------
+    ! compare a dual number with a real number, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function gt_dr(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        real, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x > rhs)
+
+    end function gt_dr
+
+
+    !-----------------------------------------
+    ! compare a dual number with an integer
+    !-----------------------------------------
+    elemental function gt_id(i, rhs) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: rhs
+        logical :: res
+
+        res = (i > rhs%x)
+
+    end function gt_id
+
+
+    !-----------------------------------------
+    ! compare a real with a dual
+    !-----------------------------------------
+    elemental function gt_rd(lhs, rhs) result(res)
+         real, intent(in) :: lhs
+         type(dual), intent(in) :: rhs
+         logical :: res
+
+         res = (lhs > rhs%x)
+
+    end function gt_rd
+
+!******* END: (>)
+!---------------------
+
+!******* BEGIN: (/=)
+!---------------------
+    !-----------------------------------------
+    ! compare two dual numbers, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function ne_dd(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs, rhs
+        logical :: res
+
+        res = (lhs%x /= rhs%x)
+
+    end function ne_dd
+
+
+    !-----------------------------------------
+    ! compare a dual with an integer
+    !-----------------------------------------
+    elemental function ne_di(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        integer, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x /= rhs)
+
+    end function ne_di
+
+
+    !-----------------------------------------
+    ! compare a dual number with a real number, simply compare
+    ! the functional value.
+    !-----------------------------------------
+    elemental function ne_dr(lhs, rhs) result(res)
+        type(dual), intent(in) :: lhs
+        real, intent(in) :: rhs
+        logical :: res
+
+        res = (lhs%x /= rhs)
+
+    end function ne_dr
+
+
+    !-----------------------------------------
+    ! compare a dual number with an integer
+    !-----------------------------------------
+    elemental function ne_id(i, rhs) result(res)
+        integer, intent(in) :: i
+        type(dual), intent(in) :: rhs
+        logical :: res
+
+        res = (i /= rhs%x)
+
+    end function ne_id
+
+
+    !-----------------------------------------
+    ! compare a real with a dual
+    !-----------------------------------------
+    elemental function ne_rd(lhs, rhs) result(res)
+        real, intent(in) :: lhs
+        type(dual), intent(in) :: rhs
+        logical :: res
+
+        res = (lhs /= rhs%x)
+
+    end function ne_rd
+
+!******* END: (/=)
+!---------------------
+
+    !---------------------------------------------------
+    ! Absolute value of dual numbers
+    ! <res, dres> = abs(<u, du>) = <abs(u), du * sign(u)>
+    !---------------------------------------------------
+    elemental function abs_d(u) result(res)
+         type(dual), intent(in) :: u
+         type(dual) :: res
+         integer :: i
+
+         if(u%x > 0) then
+            res%x = u%x
+            res%dx = u%dx
+         else if (u%x < 0) then
+            res%x = -u%x
+            res%dx = -u%dx
+         else
+            res%x = 0.0
+            do i = 1, ndv
+                if (u%dx(i) .eq. 0.0) then
+                    res%dx(i) = 0.0
+                else
+                    res%dx(i) = set_NaN()
+                end if
+            end do
+         endif
+
+    end function abs_d
+
+
+    !-----------------------------------------
+    ! ACOS of dual numbers
+    ! <res, dres> = acos(<u, du>) = <acos(u), -du / sqrt(1 - u^2)>
+    !----------------------------------------
+    elemental function acos_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = acos(u%x)
+        if (u%x == 1.0 .or. u%x == -1.0) then
+            res%dx = set_Nan()  ! Undefined derivative
+        else
+            res%dx = -u%dx / sqrt(1.0 - u%x**2)
+        end if
+
+    end function acos_d
+
+
+    !-----------------------------------------
+    ! ASIN of dual numbers
+    ! <res, dres> = asin(<u, du>) = <asin(u), du / sqrt(1 - u^2)>
+    !----------------------------------------
+    elemental function asin_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = asin(u%x)
+        if (u%x == 1.0 .or. u%x == -1.0) then
+            res%dx = set_NaN()  ! Undefined derivative
+        else
+            res%dx = u%dx / sqrt(1.0 - u%x**2)
+        end if
+
+    end function asin_d
+
+
+    !-----------------------------------------
+    ! ATAN of dual numbers
+    ! <res, dres> = atan(<u, du>) = <atan(u), du / (1 + u^2)>
+    !----------------------------------------
+    elemental function atan_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = atan(u%x)
+        res%dx = u%dx / (1.0 + u%x**2)
+
+    end function atan_d
+
+
+    !-----------------------------------------
+    ! ATAN2 of dual numbers
+    ! <res, dres> = atan2(<u, du>, <v, dv>)
+    !             = <atan2(u, v), v / (u^2 + v^2) * du - u / (u^2 + v^2) * dv>
+    !----------------------------------------
+    elemental function atan2_d(u, v) result(res)
+        type(dual), intent(in) :: u, v
+        type(dual) :: res
+
+        real :: usq_plus_vsq
+
+        res%x = atan2(u%x, v%x)
+
+        usq_plus_vsq = u%x**2 + v%x**2
+        res%dx = v%x / usq_plus_vsq * u%dx - u%x / usq_plus_vsq * v%dx
+
+    end function atan2_d
+
+
+    !-----------------------------------------
+    ! COS of dual numbers
+    ! <res, dres> = cos(<u, du>) = <cos(u), -sin(u) * du>
+    !----------------------------------------
+    elemental function cos_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = cos(u%x)
+        res%dx = -sin(u%x) * u%dx
+
+    end function cos_d
+
+
+    !-----------------------------------------
+    ! DOT PRODUCT two dual number vectors
+    ! <res, dres> = <u, du> . <v, dv> = <u . v, u . dv + v . du>
+    !-----------------------------------------
+    function dot_product_dd(u, v) result(res)
+        type(dual), intent(in) :: u(:), v(:)
+        type(dual) :: res
+
+        integer :: i
+
+        res%x = dot_product(u%x, v%x)
+        do i = 1, ndv
+            res%dx(i) = dot_product(u%x, v%dx(i)) + dot_product(v%x, u%dx(i))
+        end do
+
+    end function dot_product_dd
+
+
+    !-----------------------------------------
+    ! EXPONENTIAL OF dual numbers
+    ! <res, dres> = exp(<u, du>) = <exp(u), exp(u) * du>
+    !-----------------------------------------
+    elemental function exp_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        real :: exp_x
+
+        exp_x = exp(u%x)
+        res%x = exp_x
+        res%dx = u%dx * exp_x
+
+    end function exp_d
+
+
+    !-----------------------------------------
+    ! Convert dual to integer
+    ! i = int(<u, du>) = int(u)
+    !----------------------------------------
+    elemental function int_d(u) result(res)
+         type(dual), intent(in) :: u
+         integer :: res
+
+         res = int(u%x)
+
+    end function int_d
+
+
+    !-----------------------------------------
+    ! LOG OF dual numbers,defined for u%x>0 only
+    ! the error control should be done in the original code
+    ! in other words, if u%x<=0, it is not possible to obtain LOG.
+    ! <res, dres> = log(<u, du>) = <log(u), du / u>
+    !----------------------------------------
+    elemental function log_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        real :: inv
+
+        inv = 1.0 / u%x
+        res%x = log(u%x)
+        res%dx = u%dx * inv
+
+    end function log_d
+
+
+    !-----------------------------------------
+    ! LOG10 OF dual numbers,defined for u%x>0 only
+    ! the error control should be done in the original code
+    ! in other words, if u%x<=0, it is not possible to obtain LOG.
+    ! <res, dres> = log10(<u, du>) = <log10(u), du / (u * log(10))>
+    ! LOG<u,up>=<LOG(u),up/u>
+    !----------------------------------------
+    elemental function log10_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        real :: inv
+
+        inv = 1.0 / (u%x * log(10.0))
+        res%x = log10(u%x)
+        res%dx = u%dx * inv
+
+    end function log10_d
+
+
+    !-----------------------------------------
+    ! MULTIPLY two dual number matrices
+    ! <res, dres> = <u, du> . <v, dv> = <u . v, du . v + u . dv>
+    !----------------------------------------
+    function matmul_dd(u,v) result(res)
+        type(dual), intent(in) :: u(:,:), v(:,:)
+        type(dual) :: res(size(u,1), size(v,2))
+
+        integer :: i
+
+        res%x = matmul(u%x, v%x)
+        do i = 1, ndv
+            res%dx(i) = matmul(u%dx(i), v%x) + matmul(u%x, v%dx(i))
+        end do
+
+    end function matmul_dd
+
+
+    !-----------------------------------------
+    ! MULTIPLY a dual number matrix with a dual number
+    ! vector
+    !
+    ! <u,up>.<v,vp>=<u.v,up.v+u.vp>
+    !----------------------------------------
+    function matmul_dv(u, v) result(res)
+        type(dual), intent(in) :: u(:,:), v(:)
+        type(dual) :: res(size(u,1))
+        integer :: i
+
+        res%x = matmul(u%x, v%x)
+        do i = 1, ndv
+            res%dx(i) = matmul(u%dx(i), v%x) + matmul(u%x, v%dx(i))
+        end do
+
+    end function matmul_dv
+
+
+    !-----------------------------------------
+    ! MULTIPLY a dual vector with a  dual matrix
+    !
+    ! <u,up>.<v,vp>=<u.v,up.v+u.vp>
+    !----------------------------------------
+    function matmul_vd(u, v) result(res)
+        type(dual), intent(in) :: u(:), v(:,:)
+        type(dual) :: res(size(v, 2))
+        integer::i
+
+        res%x = matmul(u%x, v%x)
+        do i = 1, ndv
+            res%dx(i) = matmul(u%dx(i), v%x) + matmul(u%x, v%dx(i))
+        end do
+
+    end function matmul_vd
+
+    !-----------------------------------------
+    ! Obtain the max of 2 to 5 dual numbers
+    !----------------------------------------
+    elemental function max_dd(val1, val2, val3, val4,val5) result(res)
+        type(dual), intent(in) :: val1, val2
+        type(dual), intent(in), optional :: val3, val4,val5
+        type(dual) :: res
+
+        if (val1%x > val2%x) then
+            res = val1
+        else
+            res = val2
+        endif
+        if(present(val3))then
+           if(res%x < val3%x) res = val3
+        endif
+        if(present(val4))then
+           if(res%x < val4%x) res = val4
+        endif
+        if(present(val5))then
+           if(res%x < val5%x) res = val5
+        endif
+
+    end function max_dd
+
+
+    !-----------------------------------------
+    ! Obtain the max of a dual number and an integer
+    !----------------------------------------
+    elemental function max_di(u, i) result(res)
+        type(dual), intent(in) :: u
+        integer, intent(in) :: i
+        type(dual) :: res
+
+        if (u%x > i) then
+            res = u
+        else
+            res = i
+        endif
+
+    end function max_di
+
+    !-----------------------------------------
+    ! Obtain the max of a dual number and a real number
+    !----------------------------------------
+    elemental function max_dr(u, r) result(res)
+        type(dual), intent(in) :: u
+        real, intent(in) :: r
+        type(dual) :: res
+
+        if (u%x > r) then
+            res = u
+        else
+            res = r
+        endif
+
+    end function max_dr
+
+
+    !---------------------------------------------------
+    ! Obtain the max of a real and a dual
+    !---------------------------------------------------
+     elemental function max_rd(n, u) result(res)
+        real, intent(in) :: n
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        if (u%x > n) then
+            res = u
+        else
+            res = n
+        endif
+
+    end function max_rd
+
+
+    !-----------------------------------------
+    ! Obtain the max value of vector u
+    !----------------------------------------
+    function maxval_d(u) result(res)
+        type(dual), intent(in) :: u(:)
+        integer :: iloc(1)
+        type(dual) :: res
+
+        iloc=maxloc(u%x)
+        res=u(iloc(1))
+
+    end function maxval_d
+
+
+    !-----------------------------------------
+    ! Obtain the min of 2 to 4 dual numbers
+    !----------------------------------------
+    elemental function min_dd(val1, val2, val3, val4) result(res)
+        type(dual), intent(in) :: val1, val2
+        type(dual), intent(in), optional :: val3, val4
+        type(dual) :: res
+
+        if (val1%x < val2%x) then
+            res = val1
+        else
+            res = val2
+        endif
+        if(present(val3))then
+           if(res%x > val3%x) res = val3
+        endif
+        if(present(val4))then
+           if(res%x > val4%x) res = val4
+        endif
+
+    end function min_dd
+
+
+    !-----------------------------------------
+    ! Obtain the min of a dual and a double
+    !----------------------------------------
+    elemental function min_dr(u, r) result(res)
+        type(dual), intent(in) :: u
+        real, intent(in) :: r
+        type(dual) :: res
+
+        if (u%x < r) then
+            res = u
+        else
+            res = r
+        endif
+
+    end function min_dr
+
+
+  !-----------------------------------------
+    ! Obtain the min value of vector u
+    !----------------------------------------
+    function minval_d(u) result(res)
+        type(dual), intent(in) :: u(:)
+        integer :: iloc(1)
+        type(dual) :: res
+
+        iloc=minloc(u%x)
+        res=u(iloc(1))
+
+    end function minval_d
+
+    
+    !------------------------------------------------------
+    !Returns the nearest integer to u%x, ELEMENTAL
+    !------------------------------------------------------
+    elemental function nint_d(u) result(res)
+        type(dual), intent(in) :: u
+        integer :: res
+
+        res=nint(u%x)
+
+    end function nint_d
+
+
+    !----------------------------------------------------------------
+    ! SIGN(a,b) with two dual numbers as inputs,
+    ! the result will be |a| if b%x>=0, -|a| if b%x<0,ELEMENTAL
+    !----------------------------------------------------------------
+    elemental function sign_dd(val1, val2) result(res)
+        type(dual), intent(in) :: val1, val2
+        type(dual) :: res
+
+        if (val2%x < 0.0) then
+            res = -abs(val1)
+        else
+            res =  abs(val1)
+        endif
+
+     end function sign_dd
+
+
+    !----------------------------------------------------------------
+    ! SIGN(a,b) with one real and one dual number as inputs,
+    ! the result will be |a| if b%x>=0, -|a| if b%x<0,ELEMENTAL
+    !----------------------------------------------------------------
+    elemental function sign_rd(val1, val2) result(res)
+        real, intent(in) :: val1
+        type(dual), intent(in) :: val2
+        type(dual) :: res
+
+        if (val2%x < 0.0) then
+            res = -abs(val1)
+        else
+            res = abs(val1)
+        endif
+
+     end function sign_rd
+
+
+    !-----------------------------------------
+    ! SIN of dual numbers
+    ! <res, dres> = sin(<u, du>) = <sin(u), cos(u) * du>
+    !----------------------------------------
+    elemental function sin_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = sin(u%x)
+        res%dx = cos(u%x) * u%dx
+
+    end function sin_d
+
+
+    !-----------------------------------------
+    ! TAN of dual numbers
+    ! <res, dres> = tan(<u, du>) = <tan(u), du / cos(u)^2>
+    !----------------------------------------
+    elemental function tan_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+
+        res%x = tan(u%x)
+        res%dx = u%dx / cos(u%x)**2
+
+    end function tan_d
+
+
+    !-----------------------------------------
+    ! SQRT of dual numbers
+    ! <res, dres> = sqrt(<u, du>) = <sqrt(u), du / (2 * sqrt(u))>
+    !----------------------------------------
+    elemental function sqrt_d(u) result(res)
+        type(dual), intent(in) :: u
+        type(dual) :: res
+        integer :: i
+
+        res%x = sqrt(u%x)
+
+        if (res%x .ne. 0.0) then
+            res%dx = 0.5 * u%dx / res%x
+        else
+            do i = 1, ndv
+                if (u%dx(i) .eq. 0.0) then
+                    res%dx(i) = 0.0
+                else
+                    res%dx(i) = set_NaN()
+                end if
+            end do
+        end if
+
+    end function sqrt_d
+
+
+    !-----------------------------------------
+    ! Sum of a dual array
+    !-----------------------------------------
+    function sum_d(u) result(res)
+        type(dual), intent(in) :: u(:)
+        type(dual) :: res
+        integer :: i
+
+        res%x = sum(u%x)
+        do i = 1, ndv
+            res%dx(i) = sum(u%dx(i))
+        end do
+
+    end function sum_d
+
+
+    !-----------------------------------------
+    ! Find the location of the max value in an
+    ! array of dual numbers
+    !-----------------------------------------
+    function maxloc_d(array) result(ind)
+        type(dual), intent(in) :: array(:)
+        integer :: ind(1)
+
+        ind = maxloc(array%x)
+
+    end function maxloc_d
+
+
+    elemental function set_NaN() result(res)
+        real :: res
+
+        res = sqrt(negative_one)
+
+    end function set_NaN
+
+end module dnadmod

--- a/test/samples/DNAD.fpp
+++ b/test/samples/DNAD.fpp
@@ -234,75 +234,75 @@ module dnadmod
     interface abs
         module procedure abs_d  ! absolute value of a dual number, elemental
     end interface
-    
+
     public dabs
     interface dabs
         module procedure abs_d ! same as abs, used for some old fortran commands
     end interface
-    
+
     public acos
     interface acos
         module procedure acos_d ! arccosine of a dual number, elemental
     end interface
-    
+
     public asin
     interface asin
         module procedure asin_d ! arcsine of a dual number, elemental
     end interface
-    
+
     public atan
     interface atan
         module procedure atan_d ! arctan of a dual number, elemental
     end interface
-    
+
     public atan2
     interface atan2
         module procedure atan2_d ! arctan of a dual number, elemental
     end interface
-    
+
     public cos
     interface cos
         module procedure cos_d ! cosine of a dual number, elemental
     end interface
-    
+
     public dcos
     interface dcos
         module procedure cos_d ! cosine of a dual number, elemental
     end interface
-    
+
     public dot_product
     interface dot_product
         module procedure dot_product_dd ! dot product two dual number vectors
     end interface
-    
+
     public exp
     interface exp
         module procedure exp_d ! exponential of a dual number, elemental
     end interface
-    
+
     public int
     interface int
         module procedure int_d ! integer part of a dual number, elemental
     end interface
-    
+
     public log
     interface log
         module procedure log_d ! log of a dual number, elemental
     end interface
-    
+
     public log10
     interface log10
         module procedure log10_d ! log of a dual number, elemental
     end interface
-    
+
     public matmul
     interface matmul
         module procedure matmul_dd ! multiply two dual matrices
         module procedure matmul_dv ! multiply a dual matrix with a dual vector
         module procedure matmul_vd ! multiply a dual vector with a dual matrix
     end interface
-    
-    
+
+
     public max
     interface max
         module procedure max_dd ! max of from two to four dual numbers, elemental
@@ -310,74 +310,74 @@ module dnadmod
         module procedure max_dr ! max of a dual number and a real, elemental
         module procedure max_rd ! max of a real,and a dual number,  elemental
     end interface
-    
+
     public dmax1
     interface dmax1
         module procedure max_dd ! max of from two to four dual numbers, elemental
     end interface
-    
+
     public maxval
     interface maxval
         module procedure maxval_d ! maxval of a dual number vector
     end interface
-    
+
     public min
     interface min
         module procedure min_dd ! min of from two to four dual numbers, elemental
         module procedure min_dr ! min of a dual and a real, elemental
     end interface
-    
+
     public dmin1
     interface dmin1
         module procedure min_dd ! min of from two to four dual numbers, elemental
     end interface
-    
+
     public minval
     interface minval
         module procedure minval_d ! obtain the maxval  of a dual number vectgor
     end interface
-    
+
     public nint
     interface nint
         module procedure nint_d ! nearest integer to the argument, elemental
     end interface
-    
+
     public sign
     interface  sign
       module procedure  sign_dd ! sign(a,b) with two dual numbers, elemental
       module procedure  sign_rd ! sign(a,b) with a real and a dual, elemental
     end interface
-    
+
     public sin
     interface sin
         module procedure sin_d ! obtain sine of a dual number, elemental
     end interface
-    
+
     public dsin
     interface dsin
         module procedure sin_d ! obtain sine of a dual number, elemental
     end interface
-    
+
     public tan
     interface tan
         module procedure tan_d ! obtain sine of a dual number, elemental
     end interface
-    
+
     public dtan
     interface dtan
         module procedure tan_d ! obtain sine of a dual number, elemental
     end interface
-    
+
     public sqrt
     interface sqrt
         module procedure sqrt_d ! obtain the sqrt of a dual number, elemental
     end interface
-    
+
     public sum
     interface sum
         module procedure sum_d ! sum a dual array
     end interface
-    
+
     public maxloc
     interface maxloc
         module procedure maxloc_d ! location of max in a dual array
@@ -571,7 +571,7 @@ contains
 
     end function minus_di
 
-    
+
     !-------------------------------------------------
     ! dual - double
     ! <res, dres> = <u, du> - r = <u - r, du>
@@ -1677,7 +1677,7 @@ contains
 
     end function minval_d
 
-    
+
     !------------------------------------------------------
     !Returns the nearest integer to u%x, ELEMENTAL
     !------------------------------------------------------

--- a/test/test_directc.py
+++ b/test/test_directc.py
@@ -337,6 +337,25 @@ class TestDirectCGenerator(unittest.TestCase):
 
         self.assertIn("wrap_testmod_helper_set_greeting", c_code)
 
+    def test_type_member_array_uses_target_handle_size(self):
+        """Type member arrays should use the selected handle size."""
+        element = ft.Element(
+            name="values",
+            type="real",
+            attributes=["allocatable", "dimension(:)"],
+        )
+        derived = ft.Type(
+            name="owner",
+            mod_name="testmod",
+            elements=[element],
+        )
+        self.generator.root.modules[0].types = [derived]
+        self.generator.handle_size = 10
+
+        c_code = self.generator.generate_module("testmod")
+
+        self.assertIn("int dummy_this[10] = {0};", c_code)
+
 
 class TestDirectCRuntime(unittest.TestCase):
     """Runtime utilities for Direct-C mode."""

--- a/test/test_pywrapgen.py
+++ b/test/test_pywrapgen.py
@@ -6,6 +6,34 @@ from f90wrap import fortran, parser, pywrapgen
 
 class TestPyWrapGen(unittest.TestCase):
 
+    def test_array_handle_size_matches_generated_wrappers(self):
+        node = fortran.Type(name='owner', mod_name='testmod')
+        element = fortran.Element(
+            name='values',
+            type='real',
+            attributes=['dimension(:)'],
+        )
+        element.orig_name = element.name
+        generator = pywrapgen.PythonWrapperGenerator(
+            prefix='f90wrap_',
+            mod_name='test',
+            types={},
+            py_mod_names={},
+            class_names={},
+            kind_map={},
+            auto_raise='',
+            sizeof_fortran_t=10,
+        )
+
+        generator.write_sc_array_wrapper(
+            node,
+            element,
+            'dimension(:)',
+            [],
+        )
+
+        self.assertIn('f90wrap.runtime.get_array(10,', str(generator))
+
     def test_py_mod_names_mapping(self):
         '''
         Verify that --py-mod-names option correctly maps module instance names.

--- a/test/test_sizeof_fortran.py
+++ b/test/test_sizeof_fortran.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+
+from f90wrap.sizeof_fortran import (
+    probe_sizeof_fortran_t,
+    resolve_sizeof_fortran_t,
+)
+
+
+class TestSizeofFortran(unittest.TestCase):
+
+    def test_explicit_size_does_not_run_compiler(self):
+        size = resolve_sizeof_fortran_t(
+            explicit_size=10,
+            compiler="compiler-that-does-not-exist",
+        )
+
+        self.assertEqual(size, 10)
+
+    def test_explicit_size_must_be_positive(self):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            resolve_sizeof_fortran_t(explicit_size=0)
+
+    def test_probe_accepts_compiler_flags(self):
+        compiler = os.environ.get("FC", "gfortran")
+
+        size = probe_sizeof_fortran_t(f"{compiler} -fPIC")
+
+        self.assertGreater(size, 0)
+
+    def test_probe_reports_missing_compiler(self):
+        with self.assertRaisesRegex(RuntimeError, "Cannot run"):
+            probe_sizeof_fortran_t("compiler-that-does-not-exist")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- probe opaque derived-type handle size with `--fortran-compiler`, `F90WRAP_FC`, `F90`, or `FC`
- allow `--sizeof-fortran-t` for cross-compilers whose probe executable cannot run locally
- use one `integer(c_int)` element count in generated Fortran, Direct-C arrays, and generated Python array access
- add a Flang MRE and compiler-probe regression tests

The handle remains an opaque, byte-preserving container. The change does not interpret descriptor data or alter object ownership and lifetime.

This PR is stacked on #377 so its test fixture and manylinux_2_28 wheel fix are present. Once #377 merges, the remaining functional change is the issue #378 fix.

Fixes #378.

## Verification

### Test fails on main

```text
$ f90wrap --direct-c -m example example.f90
$ flang-new -c example.f90 -o example.o
$ flang-new -c f90wrap_example.f90 -o f90wrap_example.o
error: Semantic errors in f90wrap_example.f90
./f90wrap_example.f90:44:5: error: Dimension 1 of left-hand side has extent 4, but right-hand side has extent 10
      this = transfer(this_ptr, this)
      ^^^^
```

### Test passes after fix

```text
$ make -C examples/issue378_flang_handle_size clean test F90=flang-new
flang-new -fPIC -c example.f90 -o example.o
flang-new -fPIC -c f90wrap_example.f90 -o f90wrap_example.o
```

The gfortran MRE also passes.

### Regression suite

```text
$ python -m pytest -q test/test_directc.py test/test_pywrapgen.py test/test_sizeof_fortran.py
36 passed in 0.26s
```

Wheel build, isolated installation, compiled-extension import, and both Meson example entries pass. `--build --fortran-compiler flang-new` produces objects identified as LLVM Flang 22.1.6.

### RABE with Flang

Validated against [RABE PR #76](https://github.com/itpplasma/rabe/pull/76) with f90wrap built by gfortran and wrappers built by Flang:

```text
[230/230] Linking Fortran shared module python/_rabe...so
100% tests passed, 0 tests failed out of 32
handle_len 10
b_mod 1.01
covariant (0.0, 8.0)
```
